### PR TITLE
Improve device command parsing robustness

### DIFF
--- a/custom_components/sofabaton_x1s/lib/commands.py
+++ b/custom_components/sofabaton_x1s/lib/commands.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Iterator, List, Tuple
+
+
+@dataclass
+class _AssemblyState:
+    total_frames: int = 0
+    received_frames: int = 0
+    buffer: bytearray = field(default_factory=bytearray)
+
+
+class DeviceCommandAssembler:
+    """Accumulates multi-frame command payloads keyed by device ID."""
+
+    def __init__(
+        self,
+        header_opcodes: Iterable[int],
+        valid_opcodes: Iterable[int] | None = None,
+    ) -> None:
+        self._header_ops = set(header_opcodes)
+        self._valid_ops = set(valid_opcodes) if valid_opcodes is not None else set(header_opcodes)
+        self._states: Dict[int, _AssemblyState] = {}
+
+    def feed(self, opcode: int, raw_frame: bytes) -> List[Tuple[int, bytes]]:
+        """Feed a frame and return completed payloads (device ID, raw bytes)."""
+
+        if opcode not in self._valid_ops or len(raw_frame) < 5:
+            return []
+
+        payload = raw_frame[4:-1]
+        if len(payload) < 4:
+            return []
+
+        frame_index = payload[2]
+        dev_id = payload[3]
+
+        if opcode in self._header_ops:
+            state = _AssemblyState()
+            state.total_frames = int.from_bytes(payload[4:6], "big") if len(payload) >= 6 else frame_index
+            state.buffer.extend(raw_frame)
+            state.received_frames = frame_index
+            self._states[dev_id] = state
+            return self._emit_if_complete(dev_id, state)
+
+        state = self._states.get(dev_id)
+        if state is None:
+            return []
+
+        state.buffer.extend(raw_frame)
+        state.received_frames = frame_index
+        return self._emit_if_complete(dev_id, state)
+
+    def _emit_if_complete(self, dev_id: int, state: _AssemblyState) -> List[Tuple[int, bytes]]:
+        if state.total_frames and state.received_frames >= state.total_frames:
+            payload = bytes(state.buffer)
+            del self._states[dev_id]
+            return [(dev_id, payload)]
+        return []
+
+
+@dataclass
+class CommandRecord:
+    dev_id: int
+    command_id: int
+    control: bytes
+    raw_label: bytes
+
+    @classmethod
+    def from_chunk(
+        cls, chunk: bytes, dev_byte: int, *, start: int = 0
+    ) -> tuple["CommandRecord" | None, int]:
+        """Attempt to parse a record starting at ``start``.
+
+        Returns the record (or ``None`` if the slice is not a valid record)
+        along with the next offset the caller should continue from.
+        """
+
+        if start >= len(chunk):
+            return None, len(chunk)
+
+        if chunk[start] != dev_byte:
+            return None, start + 1
+
+        if start + 9 > len(chunk):
+            return None, len(chunk)
+
+        command_id = chunk[start + 1]
+        control = chunk[start + 2 : start + 9]
+
+        if not _looks_like_control_block(control):
+            return None, start + 1
+
+        label_bytes = chunk[start + 9 :]
+        if not label_bytes:
+            return None, len(chunk)
+
+        return cls(dev_byte, command_id, control, label_bytes), len(chunk)
+
+    def decode_label(self) -> str:
+        label_bytes = self.raw_label
+        if label_bytes.startswith(b"\x00\x00\x00\x00"):
+            label_bytes = label_bytes[4:]
+        label_bytes = label_bytes.rstrip(b"\x00")
+        if len(label_bytes) % 2 != 0:
+            label_bytes = label_bytes[:-1]
+        try:
+            return label_bytes.decode("utf-16be", errors="ignore").strip("\x00")
+        except UnicodeDecodeError:
+            return ""
+
+
+def _iter_chunks(raw_data: bytes) -> Iterator[bytes]:
+    for chunk in raw_data.split(b"\xFF"):
+        if chunk:
+            yield chunk
+
+
+def _looks_like_control_block(control: bytes) -> bool:
+    if len(control) != 7:
+        return False
+    if control[0] in (0x03, 0x0D):
+        return True
+    if control.startswith(b"\x1a\x00\x00\x00\x00\x17"):
+        return True
+    return False
+
+
+def iter_command_records(raw_data: bytes, dev_id: int) -> Iterator[CommandRecord]:
+    dev_byte = dev_id & 0xFF
+    for chunk in _iter_chunks(raw_data):
+        cursor = 0
+        while cursor < len(chunk):
+            record, cursor = CommandRecord.from_chunk(chunk, dev_byte, start=cursor)
+            if record:
+                yield record
+
+
+def parse_device_commands(raw_bytes: bytes, dev_id: int) -> Dict[int, str]:
+    commands: Dict[int, str] = {}
+    for record in iter_command_records(raw_bytes, dev_id):
+        label = record.decode_label()
+        if label and record.command_id not in commands:
+            commands[record.command_id] = label
+    return commands

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+custom_components = types.ModuleType("custom_components")
+custom_components.__path__ = [str(ROOT / "custom_components")]
+sys.modules.setdefault("custom_components", custom_components)
+
+sofabaton_pkg = types.ModuleType("custom_components.sofabaton_x1s")
+sofabaton_pkg.__path__ = [str(ROOT / "custom_components" / "sofabaton_x1s")]
+sys.modules.setdefault("custom_components.sofabaton_x1s", sofabaton_pkg)
+
+lib_pkg = types.ModuleType("custom_components.sofabaton_x1s.lib")
+lib_pkg.__path__ = [str(ROOT / "custom_components" / "sofabaton_x1s" / "lib")]
+sys.modules.setdefault("custom_components.sofabaton_x1s.lib", lib_pkg)
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from custom_components.sofabaton_x1s.lib.commands import (  # noqa: E402
+    DeviceCommandAssembler,
+    parse_device_commands,
+)
+from custom_components.sofabaton_x1s.lib.x1_proxy import (  # noqa: E402
+    COMMAND_FRAME_OPCODES,
+    OP_DEVBTN_HEADER,
+    OP_DEVBTN_TAIL,
+)
+
+SYNC0, SYNC1 = 0xA5, 0x5A
+
+
+def _build_record(dev_id: int, command_id: int, control: bytes, label: str) -> bytes:
+    label_bytes = label.encode("utf-16be")
+    return (
+        bytes([dev_id, command_id])
+        + control
+        + b"\x00\x00\x00\x00"
+        + label_bytes
+        + b"\x00\x00"
+    )
+
+
+def _build_frame(opcode: int, frame_index: int, dev_id: int, total_frames: int, payload: bytes) -> bytes:
+    header = bytes([SYNC0, SYNC1, (opcode >> 8) & 0xFF, opcode & 0xFF])
+    frame_payload = (
+        b"\x00\x00"
+        + bytes([frame_index & 0xFF, dev_id & 0xFF])
+        + total_frames.to_bytes(2, "big")
+        + b"\x00"
+        + payload
+    )
+    return header + frame_payload + b"\x00"
+
+
+def test_parse_device_commands_handles_legacy_record():
+    dev_id = 0x10
+    control = b"\x03\x01\x02\x03\x04\x05\x06"
+    record = _build_record(dev_id, 0x01, control, "Power Toggle")
+    raw = b"\x12\x34" + b"\xFF" + record + b"\xFF"
+
+    parsed = parse_device_commands(raw, dev_id)
+
+    assert parsed == {0x01: "Power Toggle"}
+
+
+def test_parse_device_commands_handles_hue_record():
+    dev_id = 0x10
+    control = b"\x1a\x00\x00\x00\x00\x17\x04"
+    record = _build_record(dev_id, 0x02, control, "Hue Scene")
+    raw = b"noise" + b"\xFF" + record + b"\xFF"
+
+    parsed = parse_device_commands(raw, dev_id)
+
+    assert parsed == {0x02: "Hue Scene"}
+
+
+def test_device_command_assembler_emits_payload_once_all_frames_arrive():
+    dev_id = 0x22
+    control_ir = b"\x03\x01\x00\x00\x00\x00\x01"
+    control_hue = b"\x1a\x00\x00\x00\x00\x17\x08"
+    record_ir = _build_record(dev_id, 0x01, control_ir, "Input 1")
+    record_hue = _build_record(dev_id, 0x02, control_hue, "Hue Toggle")
+    assembler = DeviceCommandAssembler({OP_DEVBTN_HEADER}, set(COMMAND_FRAME_OPCODES))
+
+    header_frame = _build_frame(OP_DEVBTN_HEADER, 1, dev_id, 2, b"\xFF" + record_ir + b"\xFF")
+    tail_frame = _build_frame(OP_DEVBTN_TAIL, 2, dev_id, 2, b"\xFF" + record_hue + b"\xFF")
+
+    assert assembler.feed(OP_DEVBTN_HEADER, header_frame) == []
+
+    completed = assembler.feed(OP_DEVBTN_TAIL, tail_frame)
+    assert completed and completed[0][0] == dev_id
+
+    combined_payload = completed[0][1]
+    commands = parse_device_commands(combined_payload, dev_id)
+
+    assert commands == {0x01: "Input 1", 0x02: "Hue Toggle"}
+
+    # A new header for the same device should start a new burst cleanly.
+    second_header = _build_frame(OP_DEVBTN_HEADER, 1, dev_id, 1, b"\xFF" + record_ir + b"\xFF")
+    next_completed = assembler.feed(OP_DEVBTN_HEADER, second_header)
+    assert next_completed and next_completed[0][0] == dev_id
+
+    next_commands = parse_device_commands(next_completed[0][1], dev_id)
+    assert next_commands == {0x01: "Input 1"}
+
+
+def test_iter_command_records_skips_malformed_chunks():
+    dev_id = 0x33
+    control = b"\x03\x01\x00\x00\x00\x00\x01"
+    valid_record = _build_record(dev_id, 0x01, control, "Input 1")
+
+    # include malformed slices before/after the valid record to ensure we still parse it
+    malformed_prefix = b"\x00\x01\x02\x03"
+    malformed_suffix = bytes([dev_id]) + b"\x02\x03"
+    raw = malformed_prefix + b"\xFF" + valid_record + b"\xFF" + malformed_suffix
+
+    parsed = parse_device_commands(raw, dev_id)
+
+    assert parsed == {0x01: "Input 1"}


### PR DESCRIPTION
## Summary
- parse command records via a structured CommandRecord helper to better handle malformed slices
- keep scanning raw command payloads without regex while tolerating noise around records
- add regression test ensuring malformed chunks do not block valid device commands

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dad1bb214832d982e2a87c622b08f)