### PR TITLE
Refactor device command parsing

### DIFF
--- a/custom_components/sofabaton_x1s/lib/commands.py
+++ b/custom_components/sofabaton_x1s/lib/commands.py
@@ -1,0 +1,137 @@
+"""Helpers for assembling and parsing device-command bursts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Iterator, List, Tuple
+
+from .protocol_const import (
+    OP_DEVBTN_EXTRA,
+    OP_DEVBTN_HEADER,
+    OP_DEVBTN_MORE,
+    OP_DEVBTN_TAIL,
+)
+
+
+@dataclass(slots=True)
+class CommandRecord:
+    """Structured representation of a single device command label."""
+
+    dev_id: int
+    command_id: int
+    control: bytes
+    label: str
+
+
+@dataclass(slots=True)
+class _CommandBurst:
+    total_frames: int | None = None
+    frames: Dict[int, bytes] = field(default_factory=dict)
+
+    @property
+    def received(self) -> int:
+        return len(self.frames)
+
+
+class DeviceCommandAssembler:
+    """Reassembles multi-frame device-command bursts by device ID."""
+
+    def __init__(self) -> None:
+        self._buffers: Dict[int, _CommandBurst] = {}
+
+    def _get_buffer(self, dev_id: int) -> _CommandBurst:
+        if dev_id not in self._buffers:
+            self._buffers[dev_id] = _CommandBurst()
+        return self._buffers[dev_id]
+
+    def _data_offset(self, opcode: int) -> int:
+        return 6
+
+    def feed(self, opcode: int, raw_frame: bytes) -> List[Tuple[int, bytes]]:
+        """Feed a raw frame and return completed payloads when available."""
+
+        if len(raw_frame) < 7:
+            return []
+
+        payload = raw_frame[4:-1]
+        if len(payload) < 4:
+            return []
+
+        dev_id = payload[3]
+        frame_no = payload[2]
+        burst = self._get_buffer(dev_id)
+
+        if opcode == OP_DEVBTN_HEADER:
+            burst.total_frames = int.from_bytes(payload[4:6], "big") if len(payload) >= 6 else None
+            burst.frames.clear()
+        elif burst.total_frames is None and opcode in (OP_DEVBTN_TAIL, OP_DEVBTN_EXTRA, OP_DEVBTN_MORE):
+            burst.total_frames = frame_no
+
+        data_start = self._data_offset(opcode)
+        frame_payload = payload[data_start:] if len(payload) > data_start else b""
+        burst.frames[frame_no] = frame_payload
+
+        completed: List[Tuple[int, bytes]] = []
+        if burst.total_frames and burst.received >= burst.total_frames:
+            ordered_payload = b"".join(burst.frames[i] for i in sorted(burst.frames))
+            completed.append((dev_id, ordered_payload))
+            del self._buffers[dev_id]
+
+        return completed
+
+
+def _decode_label(label_bytes: bytes) -> str:
+    trimmed = label_bytes
+    if trimmed.startswith(b"\x00\x00\x00\x00"):
+        trimmed = trimmed[4:]
+
+    trimmed = trimmed.rstrip(b"\x00")
+    if len(trimmed) % 2:
+        trimmed += b"\x00"
+
+    try:
+        return trimmed.decode("utf-16-be").strip("\x00")
+    except UnicodeDecodeError:
+        return ""
+
+
+def _matches_control_block(block: bytes) -> bool:
+    if len(block) != 7:
+        return False
+    if block[0] in (0x03, 0x0D):
+        return True
+    return block[:6] == b"\x1a\x00\x00\x00\x00\x17"
+
+
+def iter_command_records(data: bytes, dev_id: int) -> Iterator[CommandRecord]:
+    target = dev_id & 0xFF
+    chunks: Iterable[bytes] = data.split(b"\xff")
+
+    for chunk in chunks:
+        if len(chunk) < 9:
+            continue
+
+        for idx in range(len(chunk) - 8):
+            if chunk[idx] != target:
+                continue
+
+            control_start = idx + 2
+            control_block = chunk[control_start : control_start + 7]
+            if not _matches_control_block(control_block):
+                continue
+
+            label_start = control_start + 7
+            label = _decode_label(chunk[label_start:])
+            if not label:
+                continue
+
+            command_id = chunk[idx + 1]
+            yield CommandRecord(target, command_id, control_block, label)
+            break
+
+
+__all__ = [
+    "CommandRecord",
+    "DeviceCommandAssembler",
+    "iter_command_records",
+]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+import sys
+import types
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _ensure_stub_package(name: str, path: Path) -> None:
+    if name in sys.modules:
+        return
+    module = types.ModuleType(name)
+    module.__path__ = [str(path)]
+    sys.modules[name] = module
+
+
+_ensure_stub_package("custom_components", ROOT / "custom_components")
+_ensure_stub_package("custom_components.sofabaton_x1s", ROOT / "custom_components" / "sofabaton_x1s")
+_ensure_stub_package("custom_components.sofabaton_x1s.lib", ROOT / "custom_components" / "sofabaton_x1s" / "lib")
+
+from custom_components.sofabaton_x1s.lib.commands import DeviceCommandAssembler
+from custom_components.sofabaton_x1s.lib.protocol_const import (
+    OP_DEVBTN_HEADER,
+    OP_DEVBTN_TAIL,
+    SYNC0,
+    SYNC1,
+)
+from custom_components.sofabaton_x1s.lib.x1_proxy import X1Proxy
+
+
+def _build_frame(opcode: int, frame_no: int, total_frames: int, dev_id: int, data: bytes) -> bytes:
+    prefix = bytes([SYNC0, SYNC1, opcode >> 8, opcode & 0xFF])
+    payload = b"\x00\x00" + bytes([frame_no, dev_id]) + total_frames.to_bytes(2, "big") + data
+    frame_wo_checksum = prefix + payload
+    checksum = sum(frame_wo_checksum) & 0xFF
+    return frame_wo_checksum + bytes([checksum])
+
+
+def test_device_command_assembly_tracks_frames() -> None:
+    dev_id = 0x2A
+    payload = b"legacy_payload_chunk" + b"hue_payload_chunk"
+    data_part1 = payload[: len(payload) // 2]
+    data_part2 = payload[len(payload) // 2 :]
+
+    assembler = DeviceCommandAssembler()
+
+    header_frame = _build_frame(OP_DEVBTN_HEADER, 1, 2, dev_id, data_part1)
+    tail_frame = _build_frame(OP_DEVBTN_TAIL, 2, 2, dev_id, data_part2)
+
+    assert assembler.feed(OP_DEVBTN_HEADER, header_frame) == []
+
+    completed = assembler.feed(OP_DEVBTN_TAIL, tail_frame)
+    assert len(completed) == 1
+
+    assembled_dev_id, assembled_payload = completed[0]
+    assert assembled_dev_id == dev_id
+    assert assembled_payload == payload
+
+
+def test_parse_device_commands_handles_legacy_and_hue_formats() -> None:
+    dev_id = 0x42
+
+    legacy_record = (
+        bytes([dev_id, 0x01])
+        + b"\x03\x00\x00\x00\x00\x00\x01"
+        + b"\x00\x00\x00\x00"
+        + "Power".encode("utf-16-be")
+    )
+
+    hue_record = (
+        bytes([dev_id, 0x02])
+        + b"\x1a\x00\x00\x00\x00\x17\x02"
+        + b"\x00\x00\x00\x00"
+        + "Hue On".encode("utf-16-be")
+    )
+
+    assembled_payload = b"\xff".join([legacy_record, hue_record])
+
+    proxy = X1Proxy("127.0.0.1")
+    parsed = proxy.parse_device_commands(assembled_payload, dev_id)
+
+    assert parsed == {1: "Power", 2: "Hue On"}


### PR DESCRIPTION
## Summary
- add a DeviceCommandAssembler to track multi-frame device command bursts and replace ad-hoc hex buffers
- refactor device command parsing to operate on structured records instead of regexes
- add unit coverage for assembler behavior and for legacy/Hue command record parsing

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3af3f718832d868daee4560fe0ea)