### PR TITLE
Add transport and state helper scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,3 +270,8 @@ That way we stay fast in normal operation, but you can still explore everything 
 ## License
 
 MIT © 2025 m3tac0de.
+### Code structure
+
+- **`TransportBridge`** (`custom_components/sofabaton_x1s/lib/transport_bridge.py`) owns the TCP sockets, keepalive, and select loop between the real hub and the virtual app client. It surfaces callbacks for framed traffic in either direction as well as connection state changes.
+- **`BurstScheduler`** (`custom_components/sofabaton_x1s/lib/helpers.py`) centralizes burst tracking and post-burst draining so command dispatchers can stay simple and testable.
+- **`ActivityCache`** (`custom_components/sofabaton_x1s/lib/helpers.py`) keeps activity/device metadata and emits change notifications, allowing entities and CLIs to share the same state holder.

--- a/custom_components/sofabaton_x1s/lib/helpers.py
+++ b/custom_components/sofabaton_x1s/lib/helpers.py
@@ -1,0 +1,164 @@
+"""Shared helpers for burst management and activity/device caching."""
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Dict, Optional, Tuple
+
+
+class BurstScheduler:
+    """Track burst lifecycles and defer queued commands until bursts finish."""
+
+    def __init__(self, idle_seconds: float = 0.15, grace_period: float = 1.0) -> None:
+        self._burst_active = False
+        self._burst_kind: str | None = None
+        self._burst_last_ts = 0.0
+        self._burst_idle_s = idle_seconds
+        self._response_grace_period = grace_period
+        self._burst_queue: list[tuple[int, bytes, bool, Optional[str]]] = []
+        self._burst_listeners: dict[str, list[Callable[[str], None]]] = {}
+
+    # Listener registration -------------------------------------------------
+    def on_burst_end(self, key: str, cb: Callable[[str], None]) -> None:
+        self._burst_listeners.setdefault(key, []).append(cb)
+
+    def _notify_burst_end(self, key: str) -> None:
+        for cb in self._burst_listeners.get(key, []):
+            cb(key)
+        if ":" in key:
+            prefix = key.split(":", 1)[0]
+            for cb in self._burst_listeners.get(prefix, []):
+                cb(key)
+
+    # Burst state -----------------------------------------------------------
+    @property
+    def active(self) -> bool:
+        return self._burst_active
+
+    @property
+    def current_kind(self) -> str | None:
+        return self._burst_kind
+
+    def start_burst(self, kind: str = "generic") -> None:
+        self._burst_active = True
+        self._burst_kind = kind
+        self._burst_last_ts = time.monotonic() + self._response_grace_period
+
+    def enqueue(
+        self,
+        opcode: int,
+        payload: bytes,
+        *,
+        expects_burst: bool,
+        burst_kind: str | None,
+        can_issue: Callable[[], bool],
+        queue_frame: Callable[[int, bytes], None],
+    ) -> bool:
+        if not can_issue():
+            return False
+
+        is_burst = expects_burst
+        if self._burst_active:
+            self._burst_queue.append((opcode, payload, is_burst, burst_kind))
+            return True
+
+        if is_burst:
+            self.start_burst(burst_kind or "generic")
+        queue_frame(opcode, payload)
+        return True
+
+    def drain_if_idle(self, *, can_issue: Callable[[], bool], queue_frame: Callable[[int, bytes], None]) -> None:
+        if not self._burst_active:
+            return
+        now = time.monotonic()
+        if now - self._burst_last_ts < self._burst_idle_s:
+            return
+        self._drain_post_burst(can_issue=can_issue, queue_frame=queue_frame)
+
+    def _drain_post_burst(
+        self,
+        *,
+        can_issue: Callable[[], bool],
+        queue_frame: Callable[[int, bytes], None],
+    ) -> None:
+        finished_kind = self._burst_kind or "generic"
+        self._burst_active = False
+        self._burst_kind = None
+        self._notify_burst_end(finished_kind)
+
+        while self._burst_queue:
+            op, payload, is_burst, next_kind = self._burst_queue.pop(0)
+            if not can_issue():
+                continue
+            if is_burst:
+                self.start_burst(next_kind or "generic")
+            queue_frame(op, payload)
+            if self._burst_active:
+                break
+
+
+class ActivityCache:
+    """Track activities/devices and notify listeners on activity changes."""
+
+    def __init__(self) -> None:
+        self._current_activity: Optional[int] = None
+        self._current_activity_hint: Optional[int] = None
+        self._activities: Dict[int, Dict[str, Any]] = {}
+        self._devices: Dict[int, Dict[str, Any]] = {}
+        self._activity_listeners: list[Callable[[int | None, int | None, str | None], None]] = []
+
+    def set_hint(self, act_id: Optional[int]) -> None:
+        self._current_activity_hint = act_id
+
+    def handle_active_state(self) -> None:
+        if self._current_activity != self._current_activity_hint:
+            old = self._current_activity
+            self._current_activity = self._current_activity_hint
+            self._notify_activity_change(self._current_activity, old)
+
+    def on_activity_change(self, cb: Callable[[int | None, int | None, str | None], None]) -> None:
+        self._activity_listeners.append(cb)
+
+    def _notify_activity_change(self, new_id: int | None, old_id: int | None) -> None:
+        name = None
+        if new_id is not None:
+            name = self._activities.get(new_id & 0xFF, {}).get("name")
+        for cb in self._activity_listeners:
+            cb(new_id, old_id, name)
+
+    # Activity/device state -------------------------------------------------
+    def update_activity(self, act_id: int, payload: Dict[str, Any]) -> None:
+        self._activities[act_id & 0xFF] = payload.copy()
+
+    def update_device(self, dev_id: int, payload: Dict[str, Any]) -> None:
+        self._devices[dev_id & 0xFF] = payload.copy()
+
+    def get_activities(self) -> tuple[dict[int, dict], bool]:
+        if self._activities:
+            return ({k: v.copy() for k, v in self._activities.items()}, True)
+        return ({}, False)
+
+    def get_devices(self) -> tuple[dict[int, dict], bool]:
+        if self._devices:
+            return ({k: v.copy() for k, v in self._devices.items()}, True)
+        return ({}, False)
+
+    def activity_name(self, act_id: int | None) -> Optional[str]:
+        if act_id is None:
+            return None
+        return self._activities.get(act_id & 0xFF, {}).get("name")
+
+    @property
+    def current(self) -> Optional[int]:
+        return self._current_activity
+
+    @property
+    def hint(self) -> Optional[int]:
+        return self._current_activity_hint
+
+    @property
+    def activities(self) -> Dict[int, Dict[str, Any]]:
+        return self._activities
+
+    @property
+    def devices(self) -> Dict[int, Dict[str, Any]]:
+        return self._devices

--- a/custom_components/sofabaton_x1s/lib/transport_bridge.py
+++ b/custom_components/sofabaton_x1s/lib/transport_bridge.py
@@ -1,0 +1,311 @@
+"""Transport coordination between hub and app sockets."""
+from __future__ import annotations
+
+import logging
+import select
+import socket
+import threading
+import time
+from typing import Callable, List, Optional, Tuple
+
+from .protocol_const import SYNC0, SYNC1
+
+log = logging.getLogger("x1proxy.transport")
+
+
+def _sum8(b: bytes) -> int:
+    return sum(b) & 0xFF
+
+
+def _hexdump(data: bytes) -> str:
+    return data.hex(" ")
+
+
+def _enable_keepalive(sock: socket.socket, *, idle: int = 30, interval: int = 10, count: int = 3) -> None:
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+    except Exception:
+        pass
+    try:  # Linux
+        TCP_KEEPIDLE = getattr(socket, "TCP_KEEPIDLE", None)
+        TCP_KEEPINTVL = getattr(socket, "TCP_KEEPINTVL", None)
+        TCP_KEEPCNT = getattr(socket, "TCP_KEEPCNT", None)
+        if TCP_KEEPIDLE is not None:
+            sock.setsockopt(socket.IPPROTO_TCP, TCP_KEEPIDLE, idle)
+        if TCP_KEEPINTVL is not None:
+            sock.setsockopt(socket.IPPROTO_TCP, TCP_KEEPINTVL, interval)
+        if TCP_KEEPCNT is not None:
+            sock.setsockopt(socket.IPPROTO_TCP, TCP_KEEPCNT, count)
+    except Exception:
+        pass
+    try:  # macOS/Windows approx
+        TCP_KEEPALIVE = getattr(socket, "TCP_KEEPALIVE", None)
+        if TCP_KEEPALIVE is not None:
+            sock.setsockopt(socket.IPPROTO_TCP, TCP_KEEPALIVE, idle)
+    except Exception:
+        pass
+
+
+class Deframer:
+    def __init__(self) -> None:
+        self.buf = bytearray()
+        self._cur_start_cid: Optional[int] = None
+
+    def feed(self, data: bytes, cid: int) -> List[Tuple[int, bytes, bytes, int, int]]:
+        out: List[Tuple[int, bytes, bytes, int, int]] = []
+        if not data:
+            return out
+        self.buf.extend(data)
+        if len(self.buf) > 1_000_000:
+            del self.buf[:500_000]
+
+        while True:
+            start = self.buf.find(bytes([SYNC0, SYNC1]))
+            if start < 0:
+                self.buf.clear()
+                self._cur_start_cid = None
+                break
+            if start:
+                del self.buf[:start]
+                self._cur_start_cid = self._cur_start_cid or cid
+            if len(self.buf) < 5:
+                break
+            if self._cur_start_cid is None:
+                self._cur_start_cid = cid
+
+            nxt = self.buf.find(bytes([SYNC0, SYNC1]), 2)
+            if nxt != -1:
+                cand = bytes(self.buf[:nxt])
+                if cand and cand[-1] == (_sum8(cand[:-1]) & 0xFF):
+                    opcode = (cand[2] << 8) | cand[3]
+                    out.append((opcode, cand, cand[4:-1], self._cur_start_cid or cid, cid))
+                    del self.buf[:nxt]
+                    self._cur_start_cid = None
+                    continue
+                del self.buf[0]
+                if not (len(self.buf) >= 2 and self.buf[0] == SYNC0 and self.buf[1] == SYNC1):
+                    self._cur_start_cid = None
+                continue
+
+            cand = bytes(self.buf)
+            if len(cand) >= 5 and cand[0] == SYNC0 and cand[1] == SYNC1 and cand[-1] == (_sum8(cand[:-1]) & 0xFF):
+                opcode = (cand[2] << 8) | cand[3]
+                out.append((opcode, cand, cand[4:-1], self._cur_start_cid or cid, cid))
+                self.buf.clear()
+                self._cur_start_cid = None
+            break
+        return out
+
+
+class TransportBridge:
+    """Bridge data between hub and app sockets with frame callbacks."""
+
+    def __init__(
+        self,
+        *,
+        diag_dump: bool,
+        diag_parse: bool,
+        ka_idle: int,
+        ka_interval: int,
+        ka_count: int,
+        on_hub_frames: Callable[[List[Tuple[int, bytes, bytes, int, int]]], None],
+        on_app_frames: Callable[[List[Tuple[int, bytes, bytes, int, int]]], None],
+        on_hub_state: Callable[[bool], None],
+        on_app_state: Callable[[bool], None],
+        tick: Callable[[], None],
+    ) -> None:
+        self._diag_dump = diag_dump
+        self._diag_parse = diag_parse
+        self._ka_idle = ka_idle
+        self._ka_interval = ka_interval
+        self._ka_count = ka_count
+        self._on_hub_frames = on_hub_frames
+        self._on_app_frames = on_app_frames
+        self._on_hub_state = on_hub_state
+        self._on_app_state = on_app_state
+        self._tick = tick
+
+        self._stop = threading.Event()
+        self._hub_sock: Optional[socket.socket] = None
+        self._app_sock: Optional[socket.socket] = None
+        self._hub_lock = threading.Lock()
+        self._app_lock = threading.Lock()
+        self._cmd_lock = threading.Lock()
+        self._local_to_hub = bytearray()
+        self._chunk_id = 0
+
+        self._df_h2a = Deframer()
+        self._df_a2h = Deframer()
+
+        self._thread: Optional[threading.Thread] = None
+
+    # Socket management -----------------------------------------------------
+    def set_hub_socket(self, sock: Optional[socket.socket]) -> None:
+        with self._hub_lock:
+            if self._hub_sock is not None and self._hub_sock is not sock:
+                try:
+                    self._hub_sock.close()
+                except Exception:
+                    pass
+            self._hub_sock = sock
+            if sock is not None:
+                _enable_keepalive(sock, idle=self._ka_idle, interval=self._ka_interval, count=self._ka_count)
+        self._on_hub_state(sock is not None)
+
+    def set_app_socket(self, sock: Optional[socket.socket]) -> None:
+        with self._app_lock:
+            if self._app_sock is not None and self._app_sock is not sock:
+                try:
+                    self._app_sock.close()
+                except Exception:
+                    pass
+            self._app_sock = sock
+        self._on_app_state(sock is not None)
+
+    def queue_local_frame(self, frame: bytes) -> None:
+        with self._cmd_lock:
+            self._local_to_hub.extend(frame)
+
+    def can_issue_commands(self) -> bool:
+        with self._app_lock:
+            return self._app_sock is None
+
+    # Lifecycle -------------------------------------------------------------
+    def start(self) -> None:
+        self._stop.clear()
+        t = threading.Thread(target=self._bridge_forever, name="x1proxy-bridge", daemon=True)
+        t.start()
+        self._thread = t
+
+    def stop(self) -> None:
+        self._stop.set()
+        with self._hub_lock:
+            if self._hub_sock is not None:
+                try:
+                    self._hub_sock.close()
+                except Exception:
+                    pass
+                self._hub_sock = None
+        with self._app_lock:
+            if self._app_sock is not None:
+                try:
+                    self._app_sock.close()
+                except Exception:
+                    pass
+                self._app_sock = None
+        if self._thread:
+            self._thread.join(timeout=1.0)
+
+    # Bridge loop -----------------------------------------------------------
+    def _bridge_forever(self) -> None:
+        app_to_hub = bytearray()
+
+        while not self._stop.is_set():
+            with self._hub_lock:
+                hub = self._hub_sock
+            with self._app_lock:
+                app = self._app_sock
+
+            rlist: List[socket.socket] = []
+            if hub is not None:
+                rlist.append(hub)
+            if app is not None:
+                rlist.append(app)
+
+            wlist: List[socket.socket] = []
+            if hub is not None and (app_to_hub or self._local_to_hub):
+                wlist.append(hub)
+
+            if not rlist and not wlist:
+                time.sleep(0.05)
+                continue
+
+            try:
+                r, w, _ = select.select(rlist, wlist, [], 0.5)
+            except (OSError, ValueError):
+                continue
+
+            # HUB reads
+            if hub is not None and hub in r:
+                try:
+                    data = hub.recv(65536)
+                except (BlockingIOError, OSError):
+                    data = b""
+                if not data:
+                    with self._hub_lock:
+                        try:
+                            hub.shutdown(socket.SHUT_RDWR)
+                        except Exception:
+                            pass
+                        try:
+                            hub.close()
+                        except Exception:
+                            pass
+                        self._hub_sock = None
+                    log.info("[TCP] Hub disconnected")
+                    self._on_hub_state(False)
+                else:
+                    self._chunk_id += 1
+                    hcid = self._chunk_id
+                    if self._diag_dump:
+                        log.info("[DUMP #%d] H→A %s", hcid, _hexdump(data))
+                    if self._diag_parse:
+                        frames = self._df_h2a.feed(data, hcid)
+                        if frames:
+                            self._on_hub_frames(frames)
+                    if app is not None:
+                        try:
+                            app.sendall(data)
+                        except Exception:
+                            pass
+
+            # APP reads
+            if app is not None and app in r:
+                try:
+                    data = app.recv(65536)
+                except (BlockingIOError, OSError):
+                    data = b""
+                if not data:
+                    with self._app_lock:
+                        try:
+                            app.shutdown(socket.SHUT_RDWR)
+                        except Exception:
+                            pass
+                        try:
+                            app.close()
+                        except Exception:
+                            pass
+                        self._app_sock = None
+                    app_to_hub.clear()
+                    log.info("[TCP] App disconnected")
+                    self._on_app_state(False)
+                else:
+                    self._chunk_id += 1
+                    acid = self._chunk_id
+                    if self._diag_dump:
+                        log.info("[DUMP #%d] A→H %s", acid, _hexdump(data))
+                    if self._diag_parse:
+                        frames = self._df_a2h.feed(data, acid)
+                        if frames:
+                            self._on_app_frames(frames)
+                    app_to_hub.extend(data)
+
+            # HUB writes (local commands first, then proxied data)
+            if hub is not None and hub in w:
+                if self._local_to_hub:
+                    try:
+                        with self._cmd_lock:
+                            sent = hub.send(self._local_to_hub)
+                            if sent:
+                                del self._local_to_hub[:sent]
+                    except (BlockingIOError, InterruptedError, OSError):
+                        pass
+                if app_to_hub:
+                    try:
+                        sent = hub.send(app_to_hub)
+                        if sent:
+                            del app_to_hub[:sent]
+                    except (BlockingIOError, InterruptedError, OSError):
+                        pass
+
+            self._tick()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,31 @@
+from custom_components.sofabaton_x1s.lib.helpers import ActivityCache, BurstScheduler
+
+
+def test_burst_scheduler_drains_queue_after_idle():
+    scheduler = BurstScheduler(idle_seconds=0.0, grace_period=0.0)
+    sent: list[tuple[int, bytes]] = []
+
+    def can_issue() -> bool:
+        return True
+
+    def queue_frame(opcode: int, payload: bytes) -> None:
+        sent.append((opcode, payload))
+
+    scheduler.enqueue(0x1234, b"first", expects_burst=True, burst_kind="test", can_issue=can_issue, queue_frame=queue_frame)
+    scheduler.enqueue(0x5678, b"second", expects_burst=False, burst_kind=None, can_issue=can_issue, queue_frame=queue_frame)
+
+    scheduler.drain_if_idle(can_issue=can_issue, queue_frame=queue_frame)
+
+    assert sent == [(0x1234, b"first"), (0x5678, b"second")]
+
+
+def test_activity_cache_notifies_on_change():
+    cache = ActivityCache()
+    events: list[tuple[int | None, int | None, str | None]] = []
+
+    cache.on_activity_change(lambda new_id, old_id, name: events.append((new_id, old_id, name)))
+    cache.update_activity(1, {"name": "Watch TV"})
+    cache.set_hint(1)
+    cache.handle_active_state()
+
+    assert events == [(1, None, "Watch TV")]


### PR DESCRIPTION
## Summary
- add reusable BurstScheduler and ActivityCache helpers for burst draining and activity notifications
- introduce TransportBridge class scaffold to own socket lifecycle and frame callbacks
- document helper responsibilities in README
- add unit coverage for burst draining and activity notification

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3dd4cb9c832d8791e81faecdc2cb)