### PR TITLE
Refactor X1Proxy transport and state helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ We add a small TXT flag to the virtual hub so Home Assistant **ignores** our own
 
 ---
 
+## Proxy internals
+
+- **TransportBridge** in `custom_components/sofabaton_x1s/lib/transport_bridge.py` owns the TCP/UDP sockets and surfaces callbacks whenever hub/app frames arrive or connection state changes.
+- **BurstScheduler** in `custom_components/sofabaton_x1s/lib/state_helpers.py` coordinates burst-style hub responses so queued commands drain only after the hub finishes sending its data.
+- **ActivityCache** in `state_helpers.py` stores activity, device, button, and command metadata that both the CLI and Home Assistant entities consume.
+- **X1Proxy** now wires these pieces together, forwarding transport events into the parser/handler registry while keeping the coordination logic small and readable.
+
+---
+
 ### Networking
 
 This integration follows the same 3-step flow as the official Sofabaton app:

--- a/custom_components/sofabaton_x1s/lib/state_helpers.py
+++ b/custom_components/sofabaton_x1s/lib/state_helpers.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from typing import Any, Callable, Dict, Optional
+
+from .commands import iter_command_records
+from .protocol_const import BUTTONNAME_BY_CODE
+
+
+class ActivityCache:
+    def __init__(self) -> None:
+        self.current_activity: Optional[int] = None
+        self.current_activity_hint: Optional[int] = None
+        self.activities: Dict[int, Dict[str, Any]] = {}
+        self.devices: Dict[int, Dict[str, Any]] = {}
+        self.buttons: Dict[int, set[int]] = {}
+        self.commands: dict[int, dict[int, str]] = defaultdict(dict)
+
+    def set_hint(self, activity_id: Optional[int]) -> None:
+        self.current_activity_hint = activity_id
+
+    def update_activity_state(self) -> tuple[Optional[int], Optional[int]]:
+        if self.current_activity != self.current_activity_hint:
+            old = self.current_activity
+            self.current_activity = self.current_activity_hint
+            return self.current_activity, old
+        return self.current_activity, self.current_activity
+
+    def get_activity_name(self, act_id: Optional[int]) -> Optional[str]:
+        if act_id is None:
+            return None
+        return self.activities.get(act_id & 0xFF, {}).get("name")
+
+    def accumulate_keymap(self, act_lo: int, payload: bytes) -> None:
+        if act_lo not in self.buttons:
+            self.buttons[act_lo] = set()
+
+        i, n = 0, len(payload)
+
+        RECORD_SIZE = 18
+
+        start_index = -1
+        if n >= RECORD_SIZE:
+            for j in range(min(n - RECORD_SIZE + 1, 20)):
+                if payload[j] == act_lo:
+                    start_index = j
+                    break
+
+        if start_index >= 0:
+            i = start_index
+            while i + RECORD_SIZE <= n:
+                button_code = payload[i + 1]
+                if payload[i] == act_lo and button_code in BUTTONNAME_BY_CODE:
+                    self.buttons[act_lo].add(button_code)
+                i += RECORD_SIZE
+            return
+
+        i = 0
+        while i + 1 < n:
+            if payload[i] == act_lo:
+                button_code = payload[i + 1]
+                if button_code in BUTTONNAME_BY_CODE:
+                    if i + 7 < n and payload[i + 3 : i + 7] == b"\x00\x00\x00\x00":
+                        stride = 16
+                    else:
+                        stride = 20
+                    self.buttons[act_lo].add(button_code)
+                    i += stride
+                    continue
+            i += 1
+
+    def parse_device_commands(self, payload: bytes, dev_id: int) -> Dict[int, str]:
+        commands_found: Dict[int, str] = {}
+        for record in iter_command_records(payload, dev_id):
+            if record.command_id not in commands_found and record.label:
+                commands_found[record.command_id] = record.label
+        return commands_found
+
+
+class BurstScheduler:
+    def __init__(self, *, idle_s: float = 0.15, response_grace: float = 1.0) -> None:
+        self.idle_s = idle_s
+        self.response_grace = response_grace
+        self.active = False
+        self.kind: str | None = None
+        self.last_ts = 0.0
+        self.queue: list[tuple[int, bytes, bool, Optional[str]]] = []
+        self.listeners: dict[str, list[Callable[[str], None]]] = {}
+
+    def on_burst_end(self, key: str, cb: Callable[[str], None]) -> None:
+        self.listeners.setdefault(key, []).append(cb)
+
+    def start(self, kind: str, *, now: Optional[float] = None) -> None:
+        self.active = True
+        self.kind = kind
+        base = time.monotonic() if now is None else now
+        self.last_ts = base + self.response_grace
+
+    def queue_or_send(
+        self,
+        *,
+        opcode: int,
+        payload: bytes,
+        expects_burst: bool,
+        burst_kind: Optional[str],
+        can_issue: Callable[[], bool],
+        sender: Callable[[int, bytes], None],
+        now: Optional[float] = None,
+    ) -> bool:
+        is_burst = expects_burst
+        current_time = time.monotonic() if now is None else now
+
+        if not can_issue():
+            return False
+
+        if self.active:
+            self.queue.append((opcode, payload, is_burst, burst_kind))
+            return True
+
+        if is_burst:
+            self.start(burst_kind or "generic", now=current_time)
+
+        sender(opcode, payload)
+        return True
+
+    def tick(
+        self,
+        now: float,
+        *,
+        can_issue: Callable[[], bool],
+        sender: Callable[[int, bytes], None],
+    ) -> None:
+        if not self.active:
+            return
+        if now - self.last_ts < self.idle_s:
+            return
+        self._drain(can_issue=can_issue, sender=sender, now=now)
+
+    def _drain(
+        self,
+        *,
+        can_issue: Callable[[], bool],
+        sender: Callable[[int, bytes], None],
+        now: float,
+    ) -> None:
+        finished_kind = self.kind or "generic"
+        self.active = False
+        self.kind = None
+        self._notify_burst_end(finished_kind)
+
+        while self.queue:
+            op, payload, is_burst, next_kind = self.queue.pop(0)
+            if not can_issue():
+                continue
+            if is_burst:
+                self.start(next_kind or "generic", now=now)
+            sender(op, payload)
+            if self.active:
+                break
+
+    def _notify_burst_end(self, key: str) -> None:
+        for cb in self.listeners.get(key, []):
+            cb(key)
+        if ":" in key:
+            prefix = key.split(":", 1)[0]
+            for cb in self.listeners.get(prefix, []):
+                cb(key)
+

--- a/custom_components/sofabaton_x1s/lib/transport_bridge.py
+++ b/custom_components/sofabaton_x1s/lib/transport_bridge.py
@@ -1,0 +1,502 @@
+from __future__ import annotations
+
+import logging
+import random
+import select
+import socket
+import struct
+import threading
+import time
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
+
+from .protocol_const import OP_CALL_ME, SYNC0, SYNC1
+
+log = logging.getLogger("x1proxy.transport")
+
+
+def _sum8(b: bytes) -> int:
+    return sum(b) & 0xFF
+
+
+def _route_local_ip(peer_ip: str) -> str:
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect((peer_ip, 80))
+        return s.getsockname()[0]
+    except Exception:
+        return "127.0.0.1"
+    finally:
+        try:
+            s.close()
+        except Exception:
+            pass
+
+
+def _pick_port_near(base: int, tries: int = 64) -> int:
+    for i in range(tries):
+        cand = base + i
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(("0.0.0.0", cand))
+            s.close()
+            return cand
+        except OSError:
+            continue
+    raise OSError("No free port near %d" % base)
+
+
+def _enable_keepalive(
+    sock: socket.socket, *, idle: int = 30, interval: int = 10, count: int = 3
+) -> None:
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+    except Exception:
+        pass
+    try:  # Linux
+        TCP_KEEPIDLE = getattr(socket, "TCP_KEEPIDLE", None)
+        TCP_KEEPINTVL = getattr(socket, "TCP_KEEPINTVL", None)
+        TCP_KEEPCNT = getattr(socket, "TCP_KEEPCNT", None)
+        if TCP_KEEPIDLE is not None:
+            sock.setsockopt(socket.IPPROTO_TCP, TCP_KEEPIDLE, idle)
+        if TCP_KEEPINTVL is not None:
+            sock.setsockopt(socket.IPPROTO_TCP, TCP_KEEPINTVL, interval)
+        if TCP_KEEPCNT is not None:
+            sock.setsockopt(socket.IPPROTO_TCP, TCP_KEEPCNT, count)
+    except Exception:
+        pass
+    try:  # macOS/Windows approx
+        TCP_KEEPALIVE = getattr(socket, "TCP_KEEPALIVE", None)
+        if TCP_KEEPALIVE is not None:
+            sock.setsockopt(socket.IPPROTO_TCP, TCP_KEEPALIVE, idle)
+    except Exception:
+        pass
+
+
+class TransportBridge:
+    """Own TCP/UDP sockets and bridge app↔hub traffic.
+
+    This class is deliberately transport-only: callers provide callbacks for
+    diagnostics and higher-level parsing.
+    """
+
+    def __init__(
+        self,
+        real_hub_ip: str,
+        real_hub_udp_port: int,
+        proxy_udp_port: int,
+        hub_listen_base: int,
+        *,
+        ka_idle: int = 30,
+        ka_interval: int = 10,
+        ka_count: int = 3,
+    ) -> None:
+        self.real_hub_ip = real_hub_ip
+        self.real_hub_udp_port = int(real_hub_udp_port)
+        self.proxy_udp_port = int(proxy_udp_port)
+        self.hub_listen_base = int(hub_listen_base)
+        self.ka_idle = int(ka_idle)
+        self.ka_interval = int(ka_interval)
+        self.ka_count = int(ka_count)
+
+        self._stop = threading.Event()
+        self._hub_sock: Optional[socket.socket] = None
+        self._app_sock: Optional[socket.socket] = None
+        self._hub_lock = threading.Lock()
+        self._app_lock = threading.Lock()
+
+        self._udp_sock: Optional[socket.socket] = None
+        self._udp_thr: Optional[threading.Thread] = None
+        self._claim_thr: Optional[threading.Thread] = None
+        self._bridge_thr: Optional[threading.Thread] = None
+
+        self._hub_listen_port: Optional[int] = None
+        self._local_to_hub = bytearray()
+
+        # callbacks
+        self._hub_frame_cbs: list[Callable[[bytes, int], None]] = []
+        self._app_frame_cbs: list[Callable[[bytes, int], None]] = []
+        self._hub_state_cbs: list[Callable[[bool], None]] = []
+        self._client_state_cbs: list[Callable[[bool], None]] = []
+        self._idle_cbs: list[Callable[[float], None]] = []
+
+        self._chunk_id = 0
+        self._proxy_enabled = True
+
+    # ------------------------------------------------------------------
+    # Callback registration
+    # ------------------------------------------------------------------
+    def on_hub_frame(self, cb: Callable[[bytes, int], None]) -> None:
+        self._hub_frame_cbs.append(cb)
+
+    def on_app_frame(self, cb: Callable[[bytes, int], None]) -> None:
+        self._app_frame_cbs.append(cb)
+
+    def on_hub_state(self, cb: Callable[[bool], None]) -> None:
+        self._hub_state_cbs.append(cb)
+        cb(self.is_hub_connected)
+
+    def on_client_state(self, cb: Callable[[bool], None]) -> None:
+        self._client_state_cbs.append(cb)
+        cb(self.is_client_connected)
+
+    def on_idle(self, cb: Callable[[float], None]) -> None:
+        self._idle_cbs.append(cb)
+
+    # ------------------------------------------------------------------
+    # External control
+    # ------------------------------------------------------------------
+    @property
+    def is_hub_connected(self) -> bool:
+        with self._hub_lock:
+            return self._hub_sock is not None
+
+    @property
+    def is_client_connected(self) -> bool:
+        with self._app_lock:
+            return self._app_sock is not None
+
+    def enable_proxy(self) -> None:
+        self._proxy_enabled = True
+        log.info("[PROXY] enabled")
+
+    def disable_proxy(self) -> None:
+        self._proxy_enabled = False
+        log.info("[PROXY] disabled (existing TCP sessions stay alive)")
+
+    def can_issue_commands(self) -> bool:
+        return not self.is_client_connected
+
+    def send_local(self, payload: bytes) -> None:
+        self._local_to_hub.extend(payload)
+
+    # ------------------------------------------------------------------
+    # Networking lifecycle
+    # ------------------------------------------------------------------
+    def start(self, *, udp_port: Optional[int] = None) -> None:
+        self._stop.clear()
+        if udp_port is not None:
+            self.proxy_udp_port = udp_port
+        self._udp_sock = self._open_udp_listener()
+        self._udp_thr = threading.Thread(
+            target=self._udp_loop, name="x1proxy-udp", daemon=True
+        )
+        self._udp_thr.start()
+
+        self._claim_thr = threading.Thread(
+            target=self._hub_guard_loop, name="x1proxy-hub-guard", daemon=True
+        )
+        self._claim_thr.start()
+
+        self._bridge_thr = threading.Thread(
+            target=self._bridge_forever, name="x1proxy-bridge", daemon=True
+        )
+        self._bridge_thr.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+        if self._udp_sock is not None:
+            try:
+                self._udp_sock.close()
+            except Exception:
+                pass
+            self._udp_sock = None
+
+        with self._hub_lock:
+            if self._hub_sock:
+                try:
+                    self._hub_sock.shutdown(socket.SHUT_RDWR)
+                except Exception:
+                    pass
+                try:
+                    self._hub_sock.close()
+                except Exception:
+                    pass
+                self._hub_sock = None
+                self._notify_hub_state(False)
+
+        with self._app_lock:
+            if self._app_sock:
+                try:
+                    self._app_sock.shutdown(socket.SHUT_RDWR)
+                except Exception:
+                    pass
+                try:
+                    self._app_sock.close()
+                except Exception:
+                    pass
+                self._app_sock = None
+                self._notify_client_state(False)
+
+        log.info("[STOP] transport stopped")
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    def _open_udp_listener(self) -> socket.socket:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+        base = self.proxy_udp_port
+        last_err: Optional[Exception] = None
+
+        if base == 0:
+            s.bind(("0.0.0.0", 0))
+            self.proxy_udp_port = s.getsockname()[1]
+            log.info("[UDP] bound on *:%d (os-picked)", self.proxy_udp_port)
+            return s
+
+        for port in range(base, base + 32):
+            try:
+                s.bind(("0.0.0.0", port))
+                self.proxy_udp_port = port
+                log.info("[UDP] bound on *:%d", port)
+                return s
+            except OSError as e:
+                last_err = e
+                continue
+
+        s.close()
+        raise OSError(f"could not bind UDP near {base}: {last_err}")
+
+    def _udp_loop(self) -> None:
+        if self._udp_sock is None:
+            return
+        sock = self._udp_sock
+        log.info("[UDP] listening for APP CALL_ME on *:%d", self.proxy_udp_port)
+        while not self._stop.is_set():
+            try:
+                pkt, (src_ip, src_port) = sock.recvfrom(2048)
+            except OSError:
+                break
+            if len(pkt) < 16 or pkt[0] != SYNC0 or pkt[1] != SYNC1:
+                continue
+            op = (pkt[2] << 8) | pkt[3]
+            if op != OP_CALL_ME:
+                continue
+            try:
+                app_ip = socket.inet_ntoa(pkt[10:14])
+                app_port = struct.unpack(">H", pkt[14:16])[0]
+            except Exception:
+                continue
+            if not self._proxy_enabled:
+                continue
+            log.info(
+                "[UDP] APP CALL_ME from %s:%d -> app tcp %s:%d",
+                src_ip,
+                src_port,
+                app_ip,
+                app_port,
+            )
+            threading.Thread(
+                target=self._handle_app_session,
+                args=((app_ip, app_port),),
+                name="x1proxy-app-connect",
+                daemon=True,
+            ).start()
+
+    def _hub_guard_loop(self) -> None:
+        while not self._stop.is_set():
+            if not self.is_hub_connected:
+                ok = self._claim_once()
+                if not ok:
+                    time.sleep(0.2)
+                    continue
+            else:
+                time.sleep(0.3)
+
+    def _claim_once(self) -> bool:
+        self._hub_listen_port = _pick_port_near(self.hub_listen_base)
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind(("0.0.0.0", self._hub_listen_port))
+        srv.listen(1)
+        srv.settimeout(1.0)
+        log.info("[TCP] waiting <- HUB on *:%d (claim)", self._hub_listen_port)
+
+        udp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        my_ip = _route_local_ip(self.real_hub_ip)
+        payload = b"\x00" * 6 + socket.inet_aton(my_ip) + struct.pack(">H", self._hub_listen_port)
+        frame = bytes([SYNC0, SYNC1, (OP_CALL_ME >> 8) & 0xFF, OP_CALL_ME & 0xFF]) + payload
+        frame += bytes([_sum8(frame)])
+
+        last = 0.0
+        hub_sock = None
+        try:
+            while hub_sock is None and not self._stop.is_set():
+                now = time.time()
+                if now - last >= 2.0 + random.uniform(-0.25, 0.25):
+                    udp.sendto(frame, (self.real_hub_ip, self.real_hub_udp_port))
+                    last = now
+                try:
+                    hub_sock, hub_addr = srv.accept()
+                except socket.timeout:
+                    continue
+
+            if hub_sock is None:
+                return False
+
+            hub_sock.settimeout(0.0)
+            _enable_keepalive(
+                hub_sock, idle=self.ka_idle, interval=self.ka_interval, count=self.ka_count
+            )
+            with self._hub_lock:
+                self._hub_sock = hub_sock
+            self._notify_hub_state(True)
+            log.info("[TCP] connected <- HUB %s:%d (claimed)", *hub_addr)
+            return True
+        finally:
+            try:
+                srv.close()
+            except Exception:
+                pass
+            try:
+                udp.close()
+            except Exception:
+                pass
+
+    def _handle_app_session(self, app_addr: Tuple[str, int]) -> None:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(5.0)
+        s.connect(app_addr)
+        s.settimeout(0.0)
+        _enable_keepalive(s, idle=self.ka_idle, interval=self.ka_interval, count=self.ka_count)
+        with self._app_lock:
+            if self._app_sock is not None:
+                try:
+                    self._app_sock.shutdown(socket.SHUT_RDWR)
+                except Exception:
+                    pass
+                try:
+                    self._app_sock.close()
+                except Exception:
+                    pass
+            self._app_sock = s
+        log.info("[TCP] connected -> APP %s:%d", *app_addr)
+        self._notify_client_state(True)
+
+    def _bridge_forever(self) -> None:
+        app_to_hub = bytearray()
+
+        while not self._stop.is_set():
+            with self._hub_lock:
+                hub = self._hub_sock
+            with self._app_lock:
+                app = self._app_sock
+
+            rlist: List[socket.socket] = []
+            if hub is not None:
+                rlist.append(hub)
+            if app is not None:
+                rlist.append(app)
+
+            wlist: List[socket.socket] = []
+            if hub is not None and (app_to_hub or local_to_hub):
+                wlist.append(hub)
+
+            if not rlist and not wlist:
+                time.sleep(0.05)
+                continue
+
+            try:
+                r, w, _ = select.select(rlist, wlist, [], 0.5)
+            except (OSError, ValueError):
+                time.sleep(0.05)
+                continue
+
+            if hub is not None and hub in r:
+                try:
+                    data = hub.recv(65536)
+                except (BlockingIOError, OSError):
+                    data = b""
+                if not data:
+                    with self._hub_lock:
+                        try:
+                            hub.shutdown(socket.SHUT_RDWR)
+                        except Exception:
+                            pass
+                        try:
+                            hub.close()
+                        except Exception:
+                            pass
+                        self._hub_sock = None
+                    self._notify_hub_state(False)
+                    app_to_hub.clear()
+                else:
+                    self._chunk_id += 1
+                    cid = self._chunk_id
+                    for cb in self._hub_frame_cbs:
+                        cb(data, cid)
+                    if app is not None:
+                        try:
+                            app.sendall(data)
+                        except Exception:
+                            pass
+
+            if app is not None and app in r:
+                try:
+                    data = app.recv(65536)
+                except (BlockingIOError, OSError):
+                    data = b""
+                if not data:
+                    with self._app_lock:
+                        try:
+                            app.shutdown(socket.SHUT_RDWR)
+                        except Exception:
+                            pass
+                        try:
+                            app.close()
+                        except Exception:
+                            pass
+                        self._app_sock = None
+                    app_to_hub.clear()
+                    self._notify_client_state(False)
+                else:
+                    self._chunk_id += 1
+                    cid = self._chunk_id
+                    for cb in self._app_frame_cbs:
+                        cb(data, cid)
+                    app_to_hub.extend(data)
+
+            if hub is not None and hub in w:
+                if self._local_to_hub:
+                    try:
+                        sent = hub.send(self._local_to_hub)
+                        if sent:
+                            del self._local_to_hub[:sent]
+                    except (BlockingIOError, InterruptedError, OSError):
+                        pass
+                if app_to_hub:
+                    try:
+                        sent = hub.send(app_to_hub)
+                        if sent:
+                            del app_to_hub[:sent]
+                    except (BlockingIOError, InterruptedError, OSError):
+                        pass
+
+            for cb in self._idle_cbs:
+                cb(time.monotonic())
+
+            if self._local_to_hub:
+                with self._hub_lock:
+                    if self._hub_sock is None:
+                        self._local_to_hub.clear()
+
+    # ------------------------------------------------------------------
+    # Notifications
+    # ------------------------------------------------------------------
+    def _notify_hub_state(self, connected: bool) -> None:
+        for cb in self._hub_state_cbs:
+            try:
+                cb(connected)
+            except Exception:
+                log.exception("hub state listener failed")
+
+    def _notify_client_state(self, connected: bool) -> None:
+        for cb in self._client_state_cbs:
+            try:
+                cb(connected)
+            except Exception:
+                log.exception("client state listener failed")
+

--- a/custom_components/sofabaton_x1s/lib/x1_proxy.py
+++ b/custom_components/sofabaton_x1s/lib/x1_proxy.py
@@ -3,17 +3,14 @@
 from __future__ import annotations
 
 import logging
-import random
-import select
 import socket
 import struct
 import threading
 import time
-from collections import defaultdict
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from .frame_handlers import FrameContext, frame_handler_registry
-from .commands import DeviceCommandAssembler, iter_command_records
+from .commands import DeviceCommandAssembler
 
 from .protocol_const import (
     BUTTONNAME_BY_CODE,
@@ -52,6 +49,8 @@ from .protocol_const import (
     SYNC0,
     SYNC1,
 )
+from .state_helpers import ActivityCache, BurstScheduler
+from .transport_bridge import TransportBridge
 
 # ============================================================================
 # Utilities
@@ -178,106 +177,70 @@ class X1Proxy:
         self.mdns_txt = mdns_txt or {}
         self.diag_dump = bool(diag_dump)
         self.diag_parse = bool(diag_parse)
-        self.ka_idle = int(ka_idle)
-        self.ka_interval = int(ka_interval)
-        self.ka_count = int(ka_count)
-
-        self._stop = threading.Event()
-
-        # sockets/threads
-        self._udp_sock: Optional[socket.socket] = None
-        self._mdns_thr: Optional[threading.Thread] = None
-        self._udp_thr: Optional[threading.Thread] = None
-        self._claim_thr: Optional[threading.Thread] = None
-        self._bridge_thr: Optional[threading.Thread] = None
-
-        # session state
-        self._hub_sock: Optional[socket.socket] = None
-        self._app_sock: Optional[socket.socket] = None
-        self._hub_lock = threading.Lock()
-        self._app_lock = threading.Lock()
-
         # deframers
         self._df_h2a = Deframer()
         self._df_a2h = Deframer()
-
-        self._hub_listen_port: Optional[int] = None
-        self._chunk_id = 0
         self._adv_started = False
 
-        # local command queue → HUB (only when no APP connected)
-        self._cmd_lock = threading.Lock()
-        self._local_to_hub = bytearray()
-
-        # last activity hint + mapped ButtonNames per activity
-        self._entity_buttons: Dict[int, Set[int]] = {}
-        self._entity_commands: dict[int, dict[int, str]] = defaultdict(dict)
-
-        # activity/device caches
-        self._current_activity: Optional[int] = None
-        self._current_activity_hint: Optional[int] = None
-        self._activities: Dict[int, Dict[str, Any]] = {}  # act_id -> {"name": str, "active": bool}
-        self._devices: Dict[int, Dict[str, Any]] = {}     # dev_id -> {"brand": str, "name": str, "guid": str|None}
-        
+        self.state = ActivityCache()
         self._command_assembler = DeviceCommandAssembler()
-        
-        self._burst_active = False
-        self._burst_kind: str | None = None
-        self._burst_last_ts = 0.0
-        self._burst_queue: list[tuple[int, bytes, bool, Optional[str]]] = []
-        self._burst_idle_s = 0.15
-        self._burst_listeners: dict[str, list[callable]] = {}
-        self._response_grace_period = 1 # the hub has 1 second to start responding to our requests
+        self._burst = BurstScheduler()
         self._activity_listeners: list[callable] = []
-
-
-        self._proxy_enabled = bool(proxy_enabled)  # runtime toggle, separate from advertise_after_hub
-        self.on_burst_end("activities", self.handle_active_state)
-        
         self._hub_state_listeners: list[callable] = []
         self._client_state_listeners: list[callable] = []
+
+        self.transport = TransportBridge(
+            real_hub_ip,
+            real_hub_udp_port,
+            proxy_udp_port,
+            hub_listen_base,
+            ka_idle=ka_idle,
+            ka_interval=ka_interval,
+            ka_count=ka_count,
+        )
+        self._proxy_enabled = bool(proxy_enabled)
+        self.transport.on_hub_frame(self._handle_hub_frame)
+        self.transport.on_app_frame(self._handle_app_frame)
+        self.transport.on_hub_state(self._notify_hub_state)
+        self.transport.on_client_state(self._notify_client_state)
+        self.transport.on_idle(self._handle_idle)
+
+        self.on_burst_end("activities", self.handle_active_state)
+
         self._hub_connected: bool = False
         self._client_connected: bool = False
-        
-        self._zc = None          # type: ignore[assignment]
-        self._mdns_info = None   # type: ignore[assignment]
+
+        self._zc = None  # type: ignore[assignment]
+        self._mdns_info = None  # type: ignore[assignment]
 
     # ---------------------------------------------------------------------
     # Local command API
     # ---------------------------------------------------------------------
     def handle_active_state(self, trigger: str) -> None:
-        if self._current_activity != self._current_activity_hint:
-            old = self._current_activity
-            self._current_activity = self._current_activity_hint
-            if self._current_activity is not None:
-                self._notify_activity_change(self._current_activity & 0xFF,
-                                             old & 0xFF if old is not None else None)
+        new_id, old_id = self.state.update_activity_state()
+        if new_id != old_id:
+            if new_id is not None:
+                self._notify_activity_change(new_id & 0xFF, old_id & 0xFF if old_id is not None else None)
             else:
-                # we went from “something” to “nothing”
-                self._notify_activity_change(None, old & 0xFF if old is not None else None)
+                self._notify_activity_change(None, old_id & 0xFF if old_id is not None else None)
     
     def enable_proxy(self) -> None:
         self._proxy_enabled = True
-        # if we already have the hub and we weren't advertising, start now
-        with self._hub_lock:
-            has_hub = self._hub_sock is not None
-        if has_hub and not self._adv_started:
+        self.transport.enable_proxy()
+        if self.transport.is_hub_connected and not self._adv_started:
             self._start_discovery()
-        log.info("[PROXY] enabled")
 
     def disable_proxy(self) -> None:
         self._proxy_enabled = False
-        # close UDP so new apps can't discover/connect
+        self.transport.disable_proxy()
         self._stop_discovery()
-        log.info("[PROXY] disabled (existing TCP sessions stay alive)")
     
     def set_diag_dump(self, enable: bool) -> None:
         self.diag_dump = bool(enable)
         log.info("[PROXY] hex logging %s", "enabled" if enable else "disabled")
 
     def can_issue_commands(self) -> bool:
-        with self._app_lock:
-            return self._app_sock is None
+        return self.transport.can_issue_commands()
 
     def _build_frame(self, opcode: int, payload: bytes = b"") -> bytes:
         head = bytes([SYNC0, SYNC1, (opcode >> 8) & 0xFF, opcode & 0xFF])
@@ -292,25 +255,22 @@ class X1Proxy:
         expects_burst: bool = False,
         burst_kind: str | None = None,
     ) -> bool:
-        if not self.can_issue_commands():
-            log.info("[CMD] ignoring %s: proxy client is connected", OPNAMES.get(opcode, f"OP_{opcode:04X}"))
-            return False
-
-        is_burst = expects_burst  # you can later OR with a BURST_OPS set
-
-        # if we are already in a burst, always defer
-        if self._burst_active:
-            self._burst_queue.append((opcode, payload, is_burst, burst_kind))
-            log.info("[CMD] delaying %s until burst ends", OPNAMES.get(opcode, f"OP_{opcode:04X}"))
-            return True
-
-        # not in a burst → send now
-        if is_burst:
-            self._start_burst(burst_kind or "generic")
-
-        self._queue_local_frame(opcode, payload)
-        log.info("[CMD] queued %s (0x%04X) %dB", OPNAMES.get(opcode, f"OP_{opcode:04X}"), opcode, len(payload))
-        return True
+        sent = self._burst.queue_or_send(
+            opcode=opcode,
+            payload=payload,
+            expects_burst=expects_burst,
+            burst_kind=burst_kind,
+            can_issue=self.can_issue_commands,
+            sender=self._send_cmd_frame,
+        )
+        if sent:
+            log.info("[CMD] queued %s (0x%04X) %dB", OPNAMES.get(opcode, f"OP_{opcode:04X}"), opcode, len(payload))
+        else:
+            log.info(
+                "[CMD] ignoring %s: proxy client is connected",
+                OPNAMES.get(opcode, f"OP_{opcode:04X}"),
+            )
+        return sent
 
     def on_hub_state_change(self, cb) -> None:
         """cb(connected: bool)"""
@@ -332,7 +292,7 @@ class X1Proxy:
         #  "buttons:101"     -> just entity 101
         #  "commands"       -> all commands updates
         #  "commands:101"   -> just entity 101
-        self._burst_listeners.setdefault(key, []).append(cb)
+        self._burst.on_burst_end(key, cb)
 
     # High-level helpers
     def request_devices(self) -> bool:    return self.enqueue_cmd(OP_REQ_DEVICES, expects_burst=True, burst_kind="devices")
@@ -352,16 +312,16 @@ class X1Proxy:
         return True
         
     def get_activities(self) -> tuple[dict[int, dict], bool]:
-        if self._activities:
-            return ({k: v.copy() for k, v in self._activities.items()}, True)
+        if self.state.activities:
+            return ({k: v.copy() for k, v in self.state.activities.items()}, True)
             
         if self.can_issue_commands():
             self.enqueue_cmd(OP_REQ_ACTIVITIES, expects_burst=True, burst_kind="activities")
         return ({}, False)
 
     def get_devices(self) -> tuple[dict[int, dict], bool]:
-        if self._devices:
-            return ({k: v.copy() for k, v in self._devices.items()}, True)
+        if self.state.devices:
+            return ({k: v.copy() for k, v in self.state.devices.items()}, True)
 
         if self.can_issue_commands():
             self.enqueue_cmd(OP_REQ_DEVICES, expects_burst=True, burst_kind="devices")
@@ -369,8 +329,8 @@ class X1Proxy:
 
     def get_buttons_for_entity(self, ent_id: int, *, fetch_if_missing: bool = True) -> tuple[list[int], bool]:
         ent_lo = ent_id & 0xFF
-        if ent_lo in self._entity_buttons:
-            return (sorted(self._entity_buttons[ent_lo]), True)
+        if ent_lo in self.state.buttons:
+            return (sorted(self.state.buttons[ent_lo]), True)
 
         if fetch_if_missing and self.can_issue_commands():
             self.enqueue_cmd(
@@ -384,8 +344,8 @@ class X1Proxy:
 
     def get_commands_for_entity(self, ent_id: int, *, fetch_if_missing: bool = True) -> tuple[dict[int, str], bool]:
         ent_lo = ent_id & 0xFF
-        if ent_lo in self._entity_commands:
-            return (dict(self._entity_commands[ent_lo]), True)
+        if ent_lo in self.state.commands:
+            return (dict(self.state.commands[ent_lo]), True)
 
         if fetch_if_missing and self.can_issue_commands():
             self.enqueue_cmd(
@@ -402,11 +362,11 @@ class X1Proxy:
     
     def send_command(self, ent_id: int, key_code: int) -> bool:
         if not self.can_issue_commands():
-            log.info("[CMD] send_command ignored: proxy client is connected"); return False      
+            log.info("[CMD] send_command ignored: proxy client is connected"); return False
 
         if key_code == ButtonName.POWER_ON:
-            self._current_activity_hint = ent_id
-            
+            self.state.set_hint(ent_id)
+
         id_lo = ent_id & 0xFF
         return self.enqueue_cmd(OP_REQ_ACTIVATE, bytes([id_lo, key_code]))
 
@@ -444,151 +404,8 @@ class X1Proxy:
         self._adv_started = True
         log.info("[mDNS] registered %s on %s:%d", info.name, socket.inet_ntoa(ip_bytes), self.proxy_udp_port)
 
-
     # ---------------------------------------------------------------------
-    # UDP listener
-    # ---------------------------------------------------------------------
-    
-    def _open_udp_listener(self) -> socket.socket:
-        """
-        Bind a UDP socket. If the configured proxy_udp_port is busy,
-        try a few higher ports. Update self.proxy_udp_port to the one
-        we actually got so mDNS can advertise the right thing.
-        """
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-
-        base = self.proxy_udp_port
-        tried = 0
-        last_err = None
-
-        # if user set 0, let OS pick
-        if base == 0:
-            s.bind(("0.0.0.0", 0))
-            self.proxy_udp_port = s.getsockname()[1]
-            log.info("[UDP] bound on *:%d (os-picked)", self.proxy_udp_port)
-            return s
-
-        # otherwise try base..base+31
-        for port in range(base, base + 32):
-            try:
-                s.bind(("0.0.0.0", port))
-                self.proxy_udp_port = port
-                log.info("[UDP] bound on *:%d", port)
-                return s
-            except OSError as e:
-                last_err = e
-                tried += 1
-
-        s.close()
-        raise OSError(f"could not bind UDP near {base}: {last_err}")
-
-    
-    def _udp_loop(self) -> None:
-        s = self._udp_sock
-        if s is None:
-            # fallback: shouldn't happen if _start_discovery was used
-            s = self._open_udp_listener()
-            self._udp_sock = s
-            
-        log.info("[UDP] listening for APP CALL_ME on *:%d", self.proxy_udp_port)
-
-        while not self._stop.is_set():
-            try:
-                pkt, (src_ip, src_port) = s.recvfrom(2048)
-            except OSError:
-                break
-            if len(pkt) < 16 or pkt[0] != SYNC0 or pkt[1] != SYNC1:
-                continue
-            op = (pkt[2] << 8) | pkt[3]
-            if op != OP_CALL_ME:
-                continue
-            try:
-                app_ip = socket.inet_ntoa(pkt[10:14])
-                app_port = struct.unpack(">H", pkt[14:16])[0]
-            except Exception:
-                continue
-            if not self._proxy_enabled:
-                continue
-            log.info("[UDP] APP CALL_ME from %s:%d -> app tcp %s:%d", src_ip, src_port, app_ip, app_port)
-            threading.Thread(target=self._handle_app_session, args=((app_ip, app_port),),
-                             name="x1proxy-app-connect", daemon=True).start()
-
-    # ---------------------------------------------------------------------
-    # Claim HUB
-    # ---------------------------------------------------------------------
-    def _claim_once(self) -> bool:
-        self._hub_listen_port = _pick_port_near(self.hub_listen_base)
-        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        srv.bind(("0.0.0.0", self._hub_listen_port))
-        srv.listen(1)
-        srv.settimeout(1.0)
-        log.info("[TCP] waiting <- HUB on *:%d (claim)", self._hub_listen_port)
-
-        udp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        my_ip = _route_local_ip(self.real_hub_ip)
-        payload = b"\x00"*6 + socket.inet_aton(my_ip) + struct.pack(">H", self._hub_listen_port)
-        frame = bytes([SYNC0, SYNC1, (OP_CALL_ME >> 8) & 0xFF, OP_CALL_ME & 0xFF]) + payload
-        frame += bytes([_sum8(frame)])  
-
-        last = 0.0
-        hub_sock = None
-        try:
-            while hub_sock is None and not self._stop.is_set():
-                now = time.time()
-                if now - last >= 2.0 + random.uniform(-0.25, 0.25):
-                    udp.sendto(frame, (self.real_hub_ip, self.real_hub_udp_port))
-                    last = now
-                try:
-                    hub_sock, hub_addr = srv.accept()
-                except socket.timeout:
-                    continue
-
-            if hub_sock is None:
-                return False
-
-            hub_sock.settimeout(0.0)
-            _enable_keepalive(hub_sock, idle=self.ka_idle, interval=self.ka_interval, count=self.ka_count)
-            with self._hub_lock:
-                self._hub_sock = hub_sock
-                self._notify_hub_state(True)
-            log.info("[TCP] connected <- HUB %s:%d (claimed)", *hub_addr)
-            return True
-        finally:
-            try: srv.close()
-            except Exception: pass
-            try: udp.close()
-            except Exception: pass
-
-    def _hub_guard_loop(self) -> None:
-        while not self._stop.is_set():
-            with self._hub_lock: hub = self._hub_sock
-            if hub is None:
-                ok = self._claim_once()
-                if not ok:
-                    time.sleep(0.2); continue
-                if self._proxy_enabled and not self._adv_started:
-                    self._start_discovery()
-            else:
-                time.sleep(0.3)
-
-    def _handle_app_session(self, app_addr: Tuple[str, int]) -> None:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.settimeout(5.0); s.connect(app_addr); s.settimeout(0.0)
-        _enable_keepalive(s, idle=self.ka_idle, interval=self.ka_interval, count=self.ka_count)
-        with self._app_lock:
-            if self._app_sock is not None:
-                try: self._app_sock.shutdown(socket.SHUT_RDWR)
-                except Exception: pass
-                try: self._app_sock.close()
-                except Exception: pass
-            self._app_sock = s
-        log.info("[TCP] connected -> APP %s:%d", *app_addr)
-        self._notify_client_state(True)
-
-    # ---------------------------------------------------------------------
-    # Parsing helpers 
+    # Parsing helpers
     # ---------------------------------------------------------------------
     
     def _notify_hub_state(self, connected: bool) -> None:
@@ -611,144 +428,41 @@ class X1Proxy:
     def _notify_activity_change(self, new_id: int | None, old_id: int | None) -> None:
         name = None
         if new_id is not None:
-            name = self._activities.get(new_id & 0xFF, {}).get("name")
+            name = self.state.activities.get(new_id & 0xFF, {}).get("name")
         for cb in self._activity_listeners:
             try:
                 cb(new_id, old_id, name)
             except Exception:
                 log.exception("activity listener failed")
     
-    def _notify_burst_end(self, key: str):
-        # 1) exact listeners, e.g. "buttons:101"
-        for cb in self._burst_listeners.get(key, []):
-            cb(key)
+    def _handle_idle(self, now: float) -> None:
+        self._burst.tick(now, can_issue=self.can_issue_commands, sender=self._send_cmd_frame)
 
-        # 2) prefix listeners, e.g. "buttons"
-        if ":" in key:
-            prefix = key.split(":", 1)[0]
-            for cb in self._burst_listeners.get(prefix, []):
-                cb(key)
-
-    def _start_burst(self, kind: str = "generic") -> None:
-        self._burst_active = True
-        self._burst_kind = kind
-        self._burst_last_ts = time.monotonic() + self._response_grace_period
-        
-    def _queue_local_frame(self, opcode: int, payload: bytes) -> None:
+    def _send_cmd_frame(self, opcode: int, payload: bytes) -> None:
         frame = self._build_frame(opcode, payload)
-        with self._cmd_lock:
-            self._local_to_hub.extend(frame)
+        self.transport.send_local(frame)
 
-    def _drain_post_burst(self) -> None:
-        finished_kind = self._burst_kind or "generic"
-        self._burst_active = False
-        self._burst_kind = None
-        
-        # notify listeners before sending queued stuff
-        self._notify_burst_end(finished_kind)
+    def _handle_hub_frame(self, data: bytes, cid: int) -> None:
+        if self.diag_dump:
+            log.info("[DUMP #%d] H→A %s", cid, _hexdump(data))
+        if self.diag_parse:
+            frames = self._df_h2a.feed(data, cid)
+            if frames:
+                self._log_frames("H→A", frames)
 
-        while self._burst_queue:
-            op, payload, is_burst, next_kind = self._burst_queue.pop(0)
-            if not self.can_issue_commands():
-                log.info("[CMD] dropped post-burst %s: proxy client is connected",
-                         OPNAMES.get(op, f"OP_{op:04X}"))
-                continue
-
-            if is_burst:
-                self._start_burst(next_kind or "generic")
-
-            self._queue_local_frame(op, payload)
-            log.info("[CMD] sent post-burst %s", OPNAMES.get(op, f"OP_{op:04X}"))
-
-            # if we just started another burst, stop draining; the next round will continue
-            if self._burst_active:
-                break
+    def _handle_app_frame(self, data: bytes, cid: int) -> None:
+        if self.diag_dump:
+            log.info("[DUMP #%d] A→H %s", cid, _hexdump(data))
+        if self.diag_parse:
+            frames = self._df_a2h.feed(data, cid)
+            if frames:
+                self._log_frames("A→H", frames)
 
     def _accumulate_keymap(self, act_lo: int, payload: bytes) -> None:
-        """
-        Processes a keymap frame payload, intelligently prioritizing the 
-        fixed 18-byte record structure (0xFA3D, 0xF13D, 0x543D, 0xBB3D, etc.) by 
-        dynamically finding the record start based on the Activity ID.
-        
-        This version is robust against variable prefixes and unmapped button codes.
-        """
-        if act_lo not in self._entity_buttons:
-            self._entity_buttons[act_lo] = set()
-        
-        i, n = 0, len(payload)
-        
-        RECORD_SIZE = 18 
-        
-        # --- FIXED-STRIDE LOGIC ---
-        start_index = -1
-        
-        # 1. Search for a reliable start index for the 18-byte records
-        if n >= RECORD_SIZE:
-            
-            # Search within the first 20 bytes for the *first* occurrence of the Activity ID.
-            # This handles all known prefixes (0-byte, 7-byte, 10-byte) and finds the start of the records.
-            for j in range(min(n - RECORD_SIZE + 1, 20)): 
-                # A record must start with the Act ID.
-                # We remove the check for 'payload[j+1] in BUTTONNAME_BY_CODE' to handle unmapped buttons.
-                if payload[j] == act_lo:
-                    start_index = j
-                    break
-        
-        # 2. Execute fixed-stride parsing if a reliable start index was found
-        if start_index >= 0:
-            log.debug("Keymap: Parsing fixed 18-byte record format.")
-            
-            i = start_index 
-            while i + RECORD_SIZE <= n:
-                # The Act ID is payload[i] and Button ID is payload[i + 1]
-                button_code = payload[i + 1]
-                
-                # We commit to the 18-byte stride from start_index.
-                # We only add the button if its code is *known* (mapped to a name).
-                if payload[i] == act_lo and button_code in BUTTONNAME_BY_CODE:
-                    self._entity_buttons[act_lo].add(button_code)
-                
-                # Move to the start of the next record (fixed stride)
-                i += RECORD_SIZE
-            return
-
-        # ----------------------------------------------------------------------
-        # === ORIGINAL LOGIC: The old, variable-stride format (fallback) ===
-        # ----------------------------------------------------------------------
-        log.debug("Keymap: Parsing original variable-stride format (fallback).")
-        
-        i = 0 
-        while i + 1 < n:
-            # 1. Check for the start of a record with the correct Activity ID
-            if payload[i] == act_lo:
-                button_code = payload[i + 1]
-                
-                # 2. Check if the next byte is a known button code
-                if button_code in BUTTONNAME_BY_CODE:
-                    
-                    # 3. Use original stride determination (16 or 20 bytes)
-                    if i + 7 < n and payload[i + 3:i + 7] == b'\x00\x00\x00\x00':
-                        stride = 16
-                    else:
-                        stride = 20
-                        
-                    self._entity_buttons[act_lo].add(button_code)
-                    
-                    # 4. Move 'i' to the expected start of the next record
-                    i += stride
-                    continue
-            i += 1
+        self.state.accumulate_keymap(act_lo, payload)
 
     def parse_device_commands(self, payload: bytes, dev_id: int) -> Dict[int, str]:
-        """Parse assembled device-command payloads into command/label mappings."""
-
-        commands_found: Dict[int, str] = {}
-
-        for record in iter_command_records(payload, dev_id):
-            if record.command_id not in commands_found and record.label:
-                commands_found[record.command_id] = record.label
-
-        return commands_found
+        return self.state.parse_device_commands(payload, dev_id)
 
     # ---------------------------------------------------------------------
     # Structured frame logs
@@ -775,99 +489,6 @@ class X1Proxy:
                     log.debug("[PARSE] error while decoding op 0x%04X via %s", op, handler.__class__.__name__, exc_info=True)
 
     # ---------------------------------------------------------------------
-    # Continuous bridge
-    # ---------------------------------------------------------------------
-    def _bridge_forever(self) -> None:
-        app_to_hub = bytearray()
-
-        while not self._stop.is_set():
-            with self._hub_lock: hub = self._hub_sock
-            with self._app_lock: app = self._app_sock
-
-            rlist: List[socket.socket] = []
-            if hub is not None: rlist.append(hub)
-            if app is not None: rlist.append(app)
-
-            wlist: List[socket.socket] = []
-            if hub is not None and (app_to_hub or self._local_to_hub):
-                wlist.append(hub)
-
-            if not rlist and not wlist:
-                time.sleep(0.05); continue
-
-            try:
-                r, w, _ = select.select(rlist, wlist, [], 0.5)
-            except (OSError, ValueError):
-                time.sleep(0.05); continue
-
-            # HUB → reads
-            if hub is not None and hub in r:
-                try: data = hub.recv(65536)
-                except (BlockingIOError, OSError): data = b""
-                if not data:
-                    with self._hub_lock:
-                        try: hub.shutdown(socket.SHUT_RDWR)
-                        except Exception: pass
-                        try: hub.close()
-                        except Exception: pass
-                        self._hub_sock = None
-                        self._notify_hub_state(False)
-                    app_to_hub.clear()
-                else:
-                    self._chunk_id += 1; hcid = self._chunk_id
-                    if self.diag_dump:  log.info("[DUMP #%d] H→A %s", hcid, _hexdump(data))
-                    if self.diag_parse:
-                        frames = self._df_h2a.feed(data, hcid)
-                        if frames: self._log_frames("H→A", frames)
-                    if app is not None:
-                        try: app.sendall(data)
-                        except Exception: pass
-
-            # APP → reads
-            if app is not None and app in r:
-                try: data = app.recv(65536)
-                except (BlockingIOError, OSError): data = b""
-                if not data:
-                    with self._app_lock:
-                        try: app.shutdown(socket.SHUT_RDWR)
-                        except Exception: pass
-                        try: app.close()
-                        except Exception: pass
-                        self._app_sock = None
-                    app_to_hub.clear()
-                    log.info("[TCP] App disconnected")
-                    self._notify_client_state(False)
-                else:
-                    self._chunk_id += 1; acid = self._chunk_id
-                    if self.diag_dump:  log.info("[DUMP #%d] A→H %s", acid, _hexdump(data))
-                    if self.diag_parse:
-                        frames = self._df_a2h.feed(data, acid)
-                        if frames: self._log_frames("A→H", frames)
-                    app_to_hub.extend(data)
-
-            # HUB writes (local commands first, then proxied data)
-            if hub is not None and hub in w:
-                if self._local_to_hub:
-                    try:
-                        with self._cmd_lock:
-                            sent = hub.send(self._local_to_hub)
-                            if sent: del self._local_to_hub[:sent]
-                    except (BlockingIOError, InterruptedError, OSError):
-                        pass
-                if app_to_hub:
-                    try:
-                        sent = hub.send(app_to_hub)
-                        if sent: del app_to_hub[:sent]
-                    except (BlockingIOError, InterruptedError, OSError):
-                        pass
-                        
-            if self._burst_active:
-                now = time.monotonic()
-                if now - self._burst_last_ts >= self._burst_idle_s:
-                    self._drain_post_burst()
-
-
-    # ---------------------------------------------------------------------
     # Lifecycle
     # ---------------------------------------------------------------------
 
@@ -877,25 +498,12 @@ class X1Proxy:
         if self._adv_started:
             return
             
-        if self._udp_sock is None:
-            self._udp_sock = self._open_udp_listener()
-            
+        self.proxy_udp_port = self.transport.proxy_udp_port
         self._start_mdns()
-        t = threading.Thread(target=self._udp_loop, name="x1proxy-udp", daemon=True)
-        t.start()
-        self._udp_thr = t
         self._adv_started = True
 
     def _stop_discovery(self) -> None:
-        # stop UDP “call_me” listener first
-        if self._udp_sock is not None:
-            try:
-                self._udp_sock.close()
-            except Exception:
-                pass
-            self._udp_sock = None
-
-        # then unregister mDNS
+        # unregister mDNS
         if self._zc is not None and self._mdns_info is not None:
             try:
                 self._zc.unregister_service(self._mdns_info)
@@ -910,32 +518,13 @@ class X1Proxy:
         self._adv_started = False
     
     def start(self) -> None:
-        self._stop.clear()
-        t1 = threading.Thread(target=self._hub_guard_loop, name="x1proxy-hub-guard", daemon=True)
-        t1.start(); self._claim_thr = t1
-        t2 = threading.Thread(target=self._bridge_forever, name="x1proxy-bridge", daemon=True)
-        t2.start(); self._bridge_thr = t2
-        if self._proxy_enabled and self._hub_sock is not None and not self._adv_started:
+        self.transport.start()
+        if self._proxy_enabled and self.transport.is_hub_connected and not self._adv_started:
             self._start_discovery()
 
     def stop(self) -> None:
-        self._stop.set()
         self._stop_discovery()
-        with self._hub_lock:
-            if self._hub_sock:
-                try: self._hub_sock.shutdown(socket.SHUT_RDWR)
-                except Exception: pass
-                try: self._hub_sock.close()
-                except Exception: pass
-                self._hub_sock = None
-                self._notify_hub_state(False)
-        with self._app_lock:
-            if self._app_sock:
-                try: self._app_sock.shutdown(socket.SHUT_RDWR)
-                except Exception: pass
-                try: self._app_sock.close()
-                except Exception: pass
-                self._app_sock = None
+        self.transport.stop()
         log.info("[STOP] proxy stopped")
 
 

--- a/tests/test_state_helpers.py
+++ b/tests/test_state_helpers.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from custom_components.sofabaton_x1s.lib.state_helpers import BurstScheduler
+from custom_components.sofabaton_x1s.lib.x1_proxy import X1Proxy
+
+
+def test_burst_scheduler_drains_queue_and_notifies() -> None:
+    sent: list[tuple[int, bytes]] = []
+    notifications: list[str] = []
+
+    scheduler = BurstScheduler(idle_s=0, response_grace=0)
+    scheduler.on_burst_end("foo", lambda key: notifications.append(key))
+
+    scheduler.queue_or_send(
+        opcode=1,
+        payload=b"a",
+        expects_burst=True,
+        burst_kind="foo",
+        can_issue=lambda: True,
+        sender=lambda op, payload: sent.append((op, payload)),
+        now=0.0,
+    )
+    scheduler.queue_or_send(
+        opcode=2,
+        payload=b"b",
+        expects_burst=False,
+        burst_kind=None,
+        can_issue=lambda: True,
+        sender=lambda op, payload: sent.append((op, payload)),
+        now=0.0,
+    )
+
+    scheduler.tick(1.0, can_issue=lambda: True, sender=lambda op, payload: sent.append((op, payload)))
+
+    assert sent == [(1, b"a"), (2, b"b")]
+    assert notifications == ["foo"]
+
+
+def test_state_listeners_receive_notifications() -> None:
+    proxy = X1Proxy("1.1.1.1", proxy_udp_port=0, proxy_enabled=False, diag_dump=False, diag_parse=False)
+
+    hub_states: list[bool] = []
+    client_states: list[bool] = []
+
+    proxy.on_hub_state_change(hub_states.append)
+    proxy.on_client_state_change(client_states.append)
+
+    proxy._notify_hub_state(True)
+    proxy._notify_client_state(True)
+
+    assert hub_states == [False, True]
+    assert client_states == [False, True]


### PR DESCRIPTION
## Summary
- extract transport responsibilities into a dedicated TransportBridge with event callbacks
- move burst scheduling and activity/device caching into reusable helpers
- update opcode handling, docs, and tests to cover new boundaries and burst draining

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3ff87abc832db5970067d9140119)