### PR TITLE
Add test for new keymap table variant

### DIFF
--- a/custom_components/sofabaton_x1s/lib/opcode_handlers.py
+++ b/custom_components/sofabaton_x1s/lib/opcode_handlers.py
@@ -22,6 +22,7 @@ from .protocol_const import (
     OP_KEYMAP_TBL_B,
     OP_KEYMAP_TBL_C,
     OP_KEYMAP_TBL_D,
+    OP_KEYMAP_TBL_F,
     OP_KEYMAP_TBL_E,
     OP_REQ_ACTIVATE,
     OP_REQ_BUTTONS,
@@ -213,6 +214,7 @@ class CatalogActivityHandler(BaseFrameHandler):
         OP_KEYMAP_TBL_B,
         OP_KEYMAP_TBL_C,
         OP_KEYMAP_TBL_D,
+        OP_KEYMAP_TBL_F,
         OP_KEYMAP_TBL_E,
         OP_KEYMAP_CONT,
     ),
@@ -228,6 +230,7 @@ class KeymapHandler(BaseFrameHandler):
         activity_offsets = {
             OP_KEYMAP_CONT: 16,
             OP_KEYMAP_TBL_D: 16,
+            OP_KEYMAP_TBL_F: 16,
         }
         activity_idx = activity_offsets.get(frame.opcode, 11)
         activity_id_decimal = raw[activity_idx] if len(raw) > activity_idx else None

--- a/custom_components/sofabaton_x1s/lib/protocol_const.py
+++ b/custom_components/sofabaton_x1s/lib/protocol_const.py
@@ -64,6 +64,7 @@ OP_KEYMAP_TBL_A = 0xF13D
 OP_KEYMAP_TBL_B = 0xFA3D
 OP_KEYMAP_TBL_C = 0x3D3D  # Returned when Hue buttons requested
 OP_KEYMAP_TBL_D = 0x1E3D  # Observed keymap table variant
+OP_KEYMAP_TBL_F = 0x783D  # Observed keymap table variant
 OP_KEYMAP_TBL_E = 0xBB3D  # Observed keymap table variant
 OP_KEYMAP_CONT = 0x543D  # Observed continuation page after MARKER
 
@@ -99,6 +100,7 @@ OPNAMES: Dict[int, str] = {
     OP_KEYMAP_TBL_B: "KEYMAP_TABLE_B",
     OP_KEYMAP_TBL_C: "KEYMAP_TABLE_C",
     OP_KEYMAP_TBL_D: "KEYMAP_TABLE_D",
+    OP_KEYMAP_TBL_F: "KEYMAP_TABLE_F",
     OP_KEYMAP_TBL_E: "KEYMAP_TABLE_E",
     OP_KEYMAP_CONT: "KEYMAP_CONT",
     OP_DEVBTN_HEADER: "DEVCTL_HEADER",
@@ -144,6 +146,7 @@ __all__ = [
     "OP_KEYMAP_TBL_B",
     "OP_KEYMAP_TBL_C",
     "OP_KEYMAP_TBL_D",
+    "OP_KEYMAP_TBL_F",
     "OP_KEYMAP_TBL_E",
     "OP_KEYMAP_CONT",
     "OP_CALL_ME",

--- a/tests/test_opcode_handlers.py
+++ b/tests/test_opcode_handlers.py
@@ -42,6 +42,7 @@ from custom_components.sofabaton_x1s.lib.protocol_const import (
     ButtonName,
     OP_KEYMAP_TBL_D,
     OP_KEYMAP_TBL_E,
+    OP_KEYMAP_TBL_F,
 )
 from custom_components.sofabaton_x1s.lib.x1_proxy import X1Proxy
 
@@ -99,4 +100,29 @@ def test_keymap_table_e_adds_volume_and_transport() -> None:
         ButtonName.REW,
         ButtonName.PAUSE,
         ButtonName.FWD,
+    }
+
+
+def test_keymap_table_f_adds_color_buttons() -> None:
+    proxy = X1Proxy(
+        "127.0.0.1", proxy_udp_port=0, proxy_enabled=False, diag_dump=False, diag_parse=False
+    )
+    handler = KeymapHandler()
+
+    frame = _build_context(
+        proxy,
+        "a5 5a 78 3d 01 00 02 3c 00 00 00 00 00 00 00 00 67 bc 01 00 00 00 00 00 a6 1f 00 00 00 00 00 00 00 00 67 bd 01 00 00 00 00 1b 46 31 00 00 00 00 00 00 00 00 67 be 01 00 00 00 00 00 e7 3b 00 00 00 00 00 00 00 00 67 bf 01 00 00 00 00 00 ec 32 00 00 00 00 00 00 00 00 67 c0 01 00 00 00 00 00 f6 3f 00 00 00 00 00 00 00 00 67 c1 01 00 00 00 00 00 f1 2e 00 00 00 00 00 00 00 00 c5",
+        OP_KEYMAP_TBL_F,
+        "KEYMAP_TABLE_F",
+    )
+
+    handler.handle(frame)
+
+    assert proxy.state.buttons.get(0x67) == {
+        ButtonName.PAUSE,
+        ButtonName.FWD,
+        ButtonName.RED,
+        ButtonName.GREEN,
+        ButtonName.YELLOW,
+        ButtonName.BLUE,
     }


### PR DESCRIPTION
## Summary
- add protocol constant for the observed keymap table F opcode and handle it like other keymap pages
- add regression test to ensure table F payload parses color and transport buttons

## Testing
- pytest tests/test_opcode_handlers.py::test_keymap_table_f_adds_color_buttons -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691edeb4f080832d99437ad913ff202b)