### PR TITLE
Refine X1 catalog parsing and tests

### DIFF
--- a/custom_components/sofabaton_x1s/lib/protocol_const.py
+++ b/custom_components/sofabaton_x1s/lib/protocol_const.py
@@ -60,6 +60,10 @@ OP_DEVBTN_TAIL = 0x495D  # H→A: tail/terminator
 OP_DEVBTN_EXTRA = 0x303D  # H→A: small follow-up page sometimes present
 OP_DEVBTN_MORE = 0x8F5D  # H→A: small follow-up page sometimes present
 
+# X1 hub responses
+OP_X1_DEVICE = 0x7B0B  # Row from list of devices (X1 firmware)
+OP_X1_ACTIVITY = 0x7B3B  # Row from list of activities (X1 firmware)
+
 OP_KEYMAP_TBL_A = 0xF13D
 OP_KEYMAP_TBL_B = 0xFA3D
 OP_KEYMAP_TBL_C = 0x3D3D  # Returned when Hue buttons requested
@@ -108,6 +112,8 @@ OPNAMES: Dict[int, str] = {
     OP_DEVBTN_TAIL: "DEVCTL_LASTPAGE_TYPE1",
     OP_DEVBTN_EXTRA: "DEVCTL_LASTPAGE_TYPE2",
     OP_DEVBTN_MORE: "DEVCTL_LASTPAGE_TYPE3",
+    OP_X1_DEVICE: "X1_DEVICE",
+    OP_X1_ACTIVITY: "X1_ACTIVITY",
     # The rest are unused but kept for completeness
     OP_BANNER: "BANNER",
     OP_WIFI_FW: "WIFI_FW",
@@ -142,6 +148,8 @@ __all__ = [
     "OP_DEVBTN_TAIL",
     "OP_DEVBTN_EXTRA",
     "OP_DEVBTN_MORE",
+    "OP_X1_DEVICE",
+    "OP_X1_ACTIVITY",
     "OP_KEYMAP_TBL_A",
     "OP_KEYMAP_TBL_B",
     "OP_KEYMAP_TBL_C",


### PR DESCRIPTION
## Summary
- parse X1 device and activity rows using observed fixed offsets for ids, names, and brands
- ensure activity flags default to inactive when not present and keep burst tracking
- add regression tests with representative X1 device and activity hex frames

## Testing
- pytest tests/test_opcode_handlers.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eeb11e698832d8a4bc55b09622abe)