### PR TITLE
Classify hubs via NO value and log model details

### DIFF
--- a/custom_components/sofabaton_x1s/const.py
+++ b/custom_components/sofabaton_x1s/const.py
@@ -7,8 +7,12 @@ CONF_HOST = "host"
 CONF_PORT = "port"
 CONF_NAME = "name"
 CONF_MDNS_TXT = "mdns_txt"
+CONF_MDNS_VERSION = "mdns_version"
 CONF_PROXY_ENABLED = "proxy_enabled"
 CONF_HEX_LOGGING_ENABLED = "hex_logging_enabled"
+
+# X1S devices report a higher NO field in their mDNS TXT records
+X1S_NO_THRESHOLD = 20221120
 
 DEFAULT_PROXY_UDP_PORT = 9102
 DEFAULT_HUB_LISTEN_BASE = 8200


### PR DESCRIPTION
## Summary
- classify hubs as X1 or X1S based on the NO field in mDNS TXT records
- include model classification in discovery logging and persist it in config entries
- add a constant documenting the NO threshold used for X1S detection

## Testing
- `python -m compileall custom_components/sofabaton_x1s`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ee993e14c832dbdca38dc62585c9e)