### PR TITLE
Handle devbtn extra keymap pages

### DIFF
--- a/custom_components/sofabaton_x1s/lib/opcode_handlers.py
+++ b/custom_components/sofabaton_x1s/lib/opcode_handlers.py
@@ -352,6 +352,7 @@ class KeymapHandler(BaseFrameHandler):
             OP_KEYMAP_CONT: 16,
             OP_KEYMAP_TBL_D: 16,
             OP_KEYMAP_TBL_F: 16,
+            OP_DEVBTN_EXTRA: 16,
         }
         activity_idx = activity_offsets.get(frame.opcode, 11)
         activity_id_decimal = raw[activity_idx] if len(raw) > activity_idx else None

--- a/tests/test_opcode_handlers.py
+++ b/tests/test_opcode_handlers.py
@@ -44,6 +44,7 @@ from custom_components.sofabaton_x1s.lib.opcode_handlers import (
 )
 from custom_components.sofabaton_x1s.lib.protocol_const import (
     ButtonName,
+    OP_DEVBTN_EXTRA,
     OP_KEYMAP_TBL_D,
     OP_KEYMAP_TBL_E,
     OP_KEYMAP_TBL_F,
@@ -144,6 +145,24 @@ def test_keymap_table_f_adds_color_buttons() -> None:
         ButtonName.YELLOW,
         ButtonName.BLUE,
     }
+
+
+def test_devbtn_extra_contains_pause_and_red() -> None:
+    proxy = X1Proxy(
+        "127.0.0.1", proxy_udp_port=0, proxy_enabled=False, diag_dump=False, diag_parse=False
+    )
+    handler = KeymapHandler()
+
+    frame = _build_context(
+        proxy,
+        "a5 5a 30 3d 01 00 02 14 00 00 00 00 00 00 00 00 65 bc 02 00 00 00 00 00 a6 0e 02 00 00 00 00 00 92 0f 65 be 02 00 00 00 00 00 00 20 00 00 00 00 00 00 00 00 42",
+        OP_DEVBTN_EXTRA,
+        "DEVBTN_EXTRA",
+    )
+
+    handler.handle(frame)
+
+    assert proxy.state.buttons.get(0x65) == {ButtonName.PAUSE, ButtonName.RED}
 
 
 def test_x1_device_row_updates_state_and_burst() -> None:


### PR DESCRIPTION
## Summary
- handle DEVBTN_EXTRA keymap pages using the correct activity offset so button codes are parsed
- add regression test ensuring pause and red buttons are captured from DEVBTN_EXTRA responses

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa87b51ac832db10c3f18deb14c2b)