### PR TITLE
Remove unused imports from hub

### DIFF
--- a/custom_components/sofabaton_x1s/hub.py
+++ b/custom_components/sofabaton_x1s/hub.py
@@ -6,12 +6,10 @@ from typing import Any, Dict, Optional
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.config_entries import ConfigEntry
 
 from .const import (
     CONF_HEX_LOGGING_ENABLED,
     CONF_PROXY_ENABLED,
-    DOMAIN,
     signal_activity,
     signal_client,
     signal_hub,


### PR DESCRIPTION
## Summary
- remove unused ConfigEntry and DOMAIN imports from hub module
- keep import formatting consistent after cleanup

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920681aca70832da0894dfc82f846ec)