### PR TITLE
Use module-level ButtonName import in hub

### DIFF
--- a/custom_components/sofabaton_x1s/hub.py
+++ b/custom_components/sofabaton_x1s/hub.py
@@ -348,7 +348,6 @@ class SofabatonHub:
     
     def get_button_name_map(self) -> dict[int, str]:
         """Return a static map of button_code -> human name."""
-        from .lib.protocol_const import ButtonName  # you already import this at the top, so this can stay up there
         name_map: dict[int, str] = {}
         for attr, val in ButtonName.__dict__.items():
             if isinstance(val, int):


### PR DESCRIPTION
## Summary
- remove redundant ButtonName import inside get_button_name_map
- rely on existing module-level import for button name mapping

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692068242958832d99ee0814391c1faf)