### PR TITLE
Handle ASCII command labels and new command payloads

### DIFF
--- a/custom_components/sofabaton_x1s/lib/protocol_const.py
+++ b/custom_components/sofabaton_x1s/lib/protocol_const.py
@@ -59,6 +59,8 @@ OP_DEVBTN_PAGE = 0xD55D  # H→A: repeated pages with 2-3 entries each
 OP_DEVBTN_TAIL = 0x495D  # H→A: tail/terminator
 OP_DEVBTN_EXTRA = 0x303D  # H→A: small follow-up page sometimes present
 OP_DEVBTN_MORE = 0x8F5D  # H→A: small follow-up page sometimes present
+OP_DEVBTN_PAGE_ALT1 = 0xF75D  # H→A: variant page layout with earlier payload offset
+OP_DEVBTN_PAGE_ALT2 = 0xA35D  # H→A: variant page layout with earlier payload offset
 
 # X1 hub responses
 OP_X1_DEVICE = 0x7B0B  # Row from list of devices (X1 firmware)
@@ -114,6 +116,8 @@ OPNAMES: Dict[int, str] = {
     OP_DEVBTN_TAIL: "DEVCTL_LASTPAGE_TYPE1",
     OP_DEVBTN_EXTRA: "DEVCTL_LASTPAGE_TYPE2",
     OP_DEVBTN_MORE: "DEVCTL_LASTPAGE_TYPE3",
+    OP_DEVBTN_PAGE_ALT1: "DEVCTL_PAGE_ALT1",
+    OP_DEVBTN_PAGE_ALT2: "DEVCTL_PAGE_ALT2",
     OP_X1_DEVICE: "X1_DEVICE",
     OP_X1_ACTIVITY: "X1_ACTIVITY",
     # The rest are unused but kept for completeness
@@ -150,6 +154,8 @@ __all__ = [
     "OP_DEVBTN_TAIL",
     "OP_DEVBTN_EXTRA",
     "OP_DEVBTN_MORE",
+    "OP_DEVBTN_PAGE_ALT1",
+    "OP_DEVBTN_PAGE_ALT2",
     "OP_X1_DEVICE",
     "OP_X1_ACTIVITY",
     "OP_KEYMAP_TBL_A",


### PR DESCRIPTION
## Summary
- parse device command payloads that use ASCII labels and zero-padded control blocks
- adjust command assembler offset for new command opcodes and expose constants for alternate page layouts
- add test fixtures covering the newly observed command bursts

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69221ae8d3dc832d97c2a33d92ee3770)