### PR TITLE
Handle keymap frames only during button bursts

### DIFF
--- a/custom_components/sofabaton_x1s/lib/opcode_handlers.py
+++ b/custom_components/sofabaton_x1s/lib/opcode_handlers.py
@@ -334,11 +334,12 @@ class KeymapHandler(BaseFrameHandler):
         payload = frame.payload
         now = time.monotonic()
 
-        # Never treat responses as keymap data while a command burst is active.
-        # Command bursts re-use some of the same frame shapes as keymaps and we
-        # must avoid misclassifying those frames while device commands are
-        # being assembled.
-        if proxy._burst.active and getattr(proxy._burst, "kind", "").startswith("commands:"):
+        # Only treat responses as keymap data while a buttons burst is active.
+        # Other bursts re-use some of the same frame shapes as keymaps and we
+        # must avoid misclassifying those frames while other data is being
+        # assembled.
+        burst_kind = getattr(proxy._burst, "kind", "")
+        if proxy._burst.active and not burst_kind.startswith("buttons:"):
             return
 
         keymap_opcodes = {


### PR DESCRIPTION
## Summary
- ensure keymap frames are only processed during active button bursts
- update handler comment to reflect burst handling change

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69225b4f9e0c832db7334cb8ba5aa5bd)