### PR TITLE
Use ConfigEntry model for hub device info

### DIFF
--- a/custom_components/sofabaton_x1s/binary_sensor.py
+++ b/custom_components/sofabaton_x1s/binary_sensor.py
@@ -18,7 +18,7 @@ from .const import (
     signal_client,
     signal_hub,
 )
-from .hub import SofabatonHub
+from .hub import SofabatonHub, get_hub_model
 
 
 async def async_setup_entry(
@@ -52,6 +52,7 @@ class SofabatonClientSensor(BinarySensorEntity):
         return DeviceInfo(
             identifiers={(DOMAIN, self._entry.data[CONF_MAC])},
             name=self._entry.data[CONF_NAME],
+            model=get_hub_model(self._entry),
         )
 
     async def async_added_to_hass(self) -> None:
@@ -89,6 +90,7 @@ class SofabatonHubConnectionSensor(BinarySensorEntity):
         return DeviceInfo(
             identifiers={(DOMAIN, self._entry.data[CONF_MAC])},
             name=self._entry.data[CONF_NAME],
+            model=get_hub_model(self._entry),
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/sofabaton_x1s/button.py
+++ b/custom_components/sofabaton_x1s/button.py
@@ -18,7 +18,7 @@ from .const import (
     signal_client,
     signal_hub,
 )
-from .hub import SofabatonHub
+from .hub import SofabatonHub, get_hub_model
 from .lib.protocol_const import ButtonName  # your proxy enum
 
 _LOGGER = logging.getLogger(__name__)
@@ -82,6 +82,7 @@ class SofabatonFindRemoteButton(ButtonEntity):
         return DeviceInfo(
             identifiers={(DOMAIN, self._entry.data[CONF_MAC])},
             name=self._entry.data[CONF_NAME],
+            model=get_hub_model(self._entry),
         )
 
     async def async_added_to_hass(self) -> None:
@@ -132,6 +133,7 @@ class SofabatonDynamicButton(ButtonEntity):
         return DeviceInfo(
             identifiers={(DOMAIN, self._entry.data[CONF_MAC])},
             name=self._entry.data[CONF_NAME],
+            model=get_hub_model(self._entry),
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/sofabaton_x1s/hub.py
+++ b/custom_components/sofabaton_x1s/hub.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, Optional
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.exceptions import HomeAssistantError
@@ -16,11 +17,22 @@ from .const import (
     signal_buttons,
     signal_devices,
     signal_commands,
+    CONF_MDNS_VERSION,
 )
 from .lib.protocol_const import ButtonName
 from .lib.x1_proxy import X1Proxy
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def get_hub_model(entry: ConfigEntry) -> str:
+    """Return the model string for this hub, with a sensible default."""
+
+    model = entry.options.get(CONF_MDNS_VERSION) or entry.data.get(CONF_MDNS_VERSION)
+    if isinstance(model, str) and model:
+        return model
+
+    return "X1"
 
 
 class SofabatonHub:

--- a/custom_components/sofabaton_x1s/remote.py
+++ b/custom_components/sofabaton_x1s/remote.py
@@ -17,6 +17,7 @@ from .const import (
     signal_client,
     signal_buttons,
 )
+from .hub import get_hub_model
 
 
 async def async_setup_entry(
@@ -74,7 +75,7 @@ class SofabatonRemote(RemoteEntity):
             identifiers={(DOMAIN, self._entry.data[CONF_MAC])},
             name=self._entry.data[CONF_NAME],
             manufacturer="Sofabaton",
-            model="X1S",
+            model=get_hub_model(self._entry),
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/sofabaton_x1s/select.py
+++ b/custom_components/sofabaton_x1s/select.py
@@ -17,7 +17,7 @@ from .const import (
     signal_activity,
     signal_client,
 )
-from .hub import SofabatonHub
+from .hub import SofabatonHub, get_hub_model
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ class SofabatonActivitySelect(SelectEntity):
             identifiers={(DOMAIN, self._entry.data[CONF_MAC])},
             name=self._entry.data[CONF_NAME],
             manufacturer="Sofabaton",
-            model="X1S via proxy",
+            model=f"{get_hub_model(self._entry)} via proxy",
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/sofabaton_x1s/sensor.py
+++ b/custom_components/sofabaton_x1s/sensor.py
@@ -15,7 +15,7 @@ from .const import (
     signal_devices,
     signal_commands,
 )
-from .hub import SofabatonHub
+from .hub import SofabatonHub, get_hub_model
 
 
 async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities):
@@ -38,6 +38,7 @@ class SofabatonIndexSensor(SensorEntity):
         return DeviceInfo(
             identifiers={(DOMAIN, self._entry.data[CONF_MAC])},
             name=self._entry.data[CONF_NAME],
+            model=get_hub_model(self._entry),
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/sofabaton_x1s/switch.py
+++ b/custom_components/sofabaton_x1s/switch.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity import EntityCategory
 
 from .const import DOMAIN, CONF_MAC, CONF_NAME
-from .hub import SofabatonHub
+from .hub import SofabatonHub, get_hub_model
 
 
 async def async_setup_entry(
@@ -41,6 +41,7 @@ class SofabatonProxySwitch(SwitchEntity):
         return DeviceInfo(
             identifiers={(DOMAIN, self._entry.data[CONF_MAC])},
             name=self._entry.data[CONF_NAME],
+            model=get_hub_model(self._entry),
         )
 
     @property
@@ -70,6 +71,7 @@ class SofabatonHexLoggingSwitch(SwitchEntity):
         return DeviceInfo(
             identifiers={(DOMAIN, self._entry.data[CONF_MAC])},
             name=self._entry.data[CONF_NAME],
+            model=get_hub_model(self._entry),
         )
 
     @property


### PR DESCRIPTION
## Summary
- add a helper to derive the Sofabaton hub model from ConfigEntry data and options with a default fallback
- use the shared helper across all entities so device registry model values match the configured hub

## Testing
- python -m compileall custom_components/sofabaton_x1s


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922dfadeb00832da44027e2335a911f)