### PR TITLE
Improve diagnostics log isolation

### DIFF
--- a/custom_components/sofabaton_x1s/__init__.py
+++ b/custom_components/sofabaton_x1s/__init__.py
@@ -7,13 +7,24 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from .const import DOMAIN, PLATFORMS, DEFAULT_PROXY_UDP_PORT, DEFAULT_HUB_LISTEN_BASE, CONF_MAC, CONF_PROXY_ENABLED, CONF_HEX_LOGGING_ENABLED
+from .const import (
+    DOMAIN,
+    PLATFORMS,
+    DEFAULT_PROXY_UDP_PORT,
+    DEFAULT_HUB_LISTEN_BASE,
+    CONF_MAC,
+    CONF_PROXY_ENABLED,
+    CONF_HEX_LOGGING_ENABLED,
+)
+from .diagnostics import async_setup_diagnostics, async_teardown_diagnostics
 from .hub import SofabatonHub
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    async_setup_diagnostics(hass)
+
     data = entry.data
     opts = entry.options
 
@@ -75,6 +86,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if not hass.data[DOMAIN]:
             hass.services.async_remove(DOMAIN, "send_command")
             hass.services.async_remove(DOMAIN, "fetch_device_commands")
+            async_teardown_diagnostics(hass)
             hass.data.pop(DOMAIN)
         if hub is not None:
             await hub.async_stop()

--- a/custom_components/sofabaton_x1s/diagnostics.py
+++ b/custom_components/sofabaton_x1s/diagnostics.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+"""Support for Home Assistant diagnostics downloads."""
+
+import logging
+import re
+import socket
+from collections import deque
+from typing import Any, Iterable
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_HOST, CONF_MAC, CONF_NAME, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+SENSITIVE_FIELDS = {CONF_HOST, CONF_MAC, CONF_NAME}
+_MAX_LOG_RECORDS = 5000
+_MAX_LOG_CHARACTERS = 512 * 1024  # ~512KB cap to avoid long-term growth
+_LOG_FORMAT = "%(asctime)s %(name)s %(levelname)s: %(message)s"
+_LOGGER_NAMES = (
+    "custom_components.sofabaton_x1s",
+    "x1proxy",
+)
+
+
+class _ForwardingHandler(logging.Handler):
+    """Forward allowed records to the root logger without extra propagation."""
+
+    def __init__(self, min_level: int) -> None:
+        super().__init__(min_level)
+        self._root = logging.getLogger()
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - thin wrapper
+        if getattr(record, "_diagnostics_forwarded", False):
+            return
+
+        record._diagnostics_forwarded = True  # type: ignore[attr-defined]
+        self._root.handle(record)
+
+
+class _InMemoryLogHandler(logging.Handler):
+    """Keep a bounded list of log lines for diagnostics export."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._records: deque[str] = deque(maxlen=_MAX_LOG_RECORDS)
+        self._current_chars = 0
+        self.setFormatter(logging.Formatter(_LOG_FORMAT))
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - thin wrapper
+        try:
+            if len(self._records) == self._records.maxlen:
+                removed = self._records.popleft()
+                self._current_chars -= len(removed)
+
+            formatted = self.format(record)
+            formatted_length = len(formatted)
+            self._records.append(formatted)
+            self._current_chars += formatted_length
+
+            while self._current_chars > _MAX_LOG_CHARACTERS and self._records:
+                removed = self._records.popleft()
+                self._current_chars -= len(removed)
+        except Exception:  # noqa: BLE001 - defensive, diagnostics should never break logging
+            _LOGGER.debug("Failed to record diagnostic log", exc_info=True)
+
+    def get_records(self) -> list[str]:
+        return list(self._records)
+
+    def detach(self) -> None:
+        """Remove this handler from the loggers we attached to."""
+
+        for logger_name in _LOGGER_NAMES:
+            logger = logging.getLogger(logger_name)
+            logger.removeHandler(self)
+
+
+def _get_handler(hass: HomeAssistant) -> _InMemoryLogHandler:
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    handler: _InMemoryLogHandler | None = domain_data.get("_diag_handler")
+    if handler:
+        return handler
+
+    handler = _InMemoryLogHandler()
+    domain_data["_diag_handler"] = handler
+    domain_data["_logger_state"] = {}
+    domain_data["_forwarders"] = {}
+
+    for logger_name in _LOGGER_NAMES:
+        logger = logging.getLogger(logger_name)
+
+        domain_data["_logger_state"][logger_name] = (
+            logger.level,
+            logger.propagate,
+        )
+
+        logger.setLevel(logging.DEBUG)
+        logger.propagate = False
+        logger.addHandler(handler)
+
+        forwarder = _ForwardingHandler(logging.INFO)
+        logger.addHandler(forwarder)
+        domain_data["_forwarders"][logger_name] = forwarder
+
+    return handler
+
+
+def async_teardown_diagnostics(hass: HomeAssistant) -> None:
+    """Detach diagnostic logging when the integration is fully removed."""
+
+    domain_data = hass.data.get(DOMAIN, {})
+    handler: _InMemoryLogHandler | None = domain_data.pop("_diag_handler", None)
+    logger_state: dict[str, tuple[int, bool]] = domain_data.pop("_logger_state", {})
+    forwarders: dict[str, _ForwardingHandler] = domain_data.pop("_forwarders", {})
+    if handler:
+        handler.detach()
+    for logger_name, forwarder in forwarders.items():
+        logging.getLogger(logger_name).removeHandler(forwarder)
+    for logger_name, (level, propagate) in logger_state.items():
+        logger = logging.getLogger(logger_name)
+        logger.setLevel(level)
+        logger.propagate = propagate
+
+
+def async_setup_diagnostics(hass: HomeAssistant) -> None:
+    """Ensure our in-memory log handler is registered once."""
+
+    if hass.data.get(DOMAIN, {}).get("_diag_handler"):
+        return
+
+    handler = _get_handler(hass)
+    _LOGGER.debug("Diagnostics log handler registered: %s", handler)
+
+
+def _sanitize_log_lines(lines: Iterable[str], entry: ConfigEntry) -> list[str]:
+    """Remove IP/hostname details from log lines."""
+
+    host = entry.data.get(CONF_HOST)
+    hostname = socket.gethostname()
+    patterns: list[tuple[re.Pattern[str], str]] = [
+        (re.compile(r"\b\d{1,3}(?:\.\d{1,3}){3}\b"), "[REDACTED_IP]"),
+    ]
+
+    if isinstance(host, str) and host:
+        patterns.append((re.compile(re.escape(host), re.IGNORECASE), "[REDACTED_HOST]"))
+    if hostname:
+        patterns.append((re.compile(re.escape(hostname), re.IGNORECASE), "[REDACTED_HOSTNAME]"))
+
+    sanitized: list[str] = []
+    for line in lines:
+        cleaned = line
+        for pattern, replacement in patterns:
+            cleaned = pattern.sub(replacement, cleaned)
+        sanitized.append(cleaned)
+
+    return sanitized
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+
+    handler = _get_handler(hass)
+
+    entry_dict = {
+        "data": async_redact_data(entry.data, SENSITIVE_FIELDS),
+        "options": async_redact_data(entry.options, SENSITIVE_FIELDS),
+    }
+
+    # Collect any cached hub information without exposing sensitive fields
+    hub = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    hub_state: dict[str, Any] = {}
+    if hub is not None:
+        hub_state = async_redact_data(
+            {
+                "name": getattr(hub, "name", None),
+                "host": getattr(hub, "host", None),
+                "port": getattr(hub, "port", None),
+                "mac": getattr(hub, "mac", None),
+                "proxy_enabled": getattr(hub, "proxy_enabled", None),
+                "hex_logging_enabled": getattr(hub, "hex_logging_enabled", None),
+                "activities": getattr(hub, "activities", None),
+                "devices": getattr(hub, "devices", None),
+                "current_activity": getattr(hub, "current_activity", None),
+                "client_connected": getattr(hub, "client_connected", None),
+                "hub_connected": getattr(hub, "hub_connected", None),
+            },
+            SENSITIVE_FIELDS,
+        )
+
+    logs = _sanitize_log_lines(handler.get_records(), entry)
+
+    return {
+        "entry": entry_dict,
+        "hub": hub_state,
+        "logs": logs,
+    }


### PR DESCRIPTION
## Summary
- limit diagnostics capture to Sofabaton and proxy loggers while keeping previous logger state
- forward only info-and-higher messages to Home Assistant logs so debug diagnostics stay in-memory

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69231f4235f4832d9b232bc8bb0214c2)