### PR TITLE
Start mDNS advertising when hub connects

### DIFF
--- a/custom_components/sofabaton_x1s/lib/x1_proxy.py
+++ b/custom_components/sofabaton_x1s/lib/x1_proxy.py
@@ -438,6 +438,8 @@ class X1Proxy:
     
     def _notify_hub_state(self, connected: bool) -> None:
         self._hub_connected = connected
+        if connected and self._proxy_enabled and not self._adv_started:
+            self._start_discovery()
         for cb in self._hub_state_listeners:
             try:
                 cb(connected)


### PR DESCRIPTION
## Summary
- trigger mDNS advertisement when the hub connection becomes available, avoiding the need to toggle the proxy switch

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692382d5b7ec832d988e4c7038962c06)