### PR TITLE
Update manual setup translations for hub name

### DIFF
--- a/custom_components/sofabaton_x1s/translations/en.json
+++ b/custom_components/sofabaton_x1s/translations/en.json
@@ -7,9 +7,9 @@
       },
       "manual": {
         "title": "Manual hub setup",
-        "description": "Enter the IP address and port of your Sofabaton hub. The default port is 8102.",
+        "description": "Provide a name, IP address, and port for your Sofabaton hub. The name is broadcast via mDNS. The default port is 8102.",
         "data": {
-          "name": "Entry name (for Home Assistant)",
+          "name": "Hub name (broadcast on your network)",
           "host": "Hub IP address",
           "port": "Hub TCP port"
         }


### PR DESCRIPTION
## Summary
- clarify manual setup description to mention the required name and its mDNS broadcast
- update the manual form label to reflect the hub name used on the network

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924506fd3d4832d9524c1652ef51552)