### PR TITLE
Add iOS advertising switch for broadcast listener

### DIFF
--- a/custom_components/sofabaton_x1s/__init__.py
+++ b/custom_components/sofabaton_x1s/__init__.py
@@ -12,9 +12,11 @@ from .const import (
     PLATFORMS,
     DEFAULT_PROXY_UDP_PORT,
     DEFAULT_HUB_LISTEN_BASE,
+    DEFAULT_BROADCAST_CALL_ME,
     CONF_MAC,
     CONF_PROXY_ENABLED,
     CONF_HEX_LOGGING_ENABLED,
+    CONF_BROADCAST_CALL_ME,
 )
 from .diagnostics import (
     async_disable_hex_logging_capture,
@@ -37,6 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     proxy_enabled = opts.get(CONF_PROXY_ENABLED, True)
     hex_logging_enabled = opts.get(CONF_HEX_LOGGING_ENABLED, False)
+    broadcast_call_me = opts.get(CONF_BROADCAST_CALL_ME, DEFAULT_BROADCAST_CALL_ME)
 
     hub = SofabatonHub(
         hass=hass,
@@ -49,6 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hub_listen_base=hub_listen_base,
         proxy_enabled=proxy_enabled,
         hex_logging_enabled=hex_logging_enabled,
+        broadcast_call_me=broadcast_call_me,
     )
     await hub.async_start()
 
@@ -75,12 +79,14 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
     new_port = entry.data.get("port", hub.port)
     proxy_udp_port = entry.options.get("proxy_udp_port", DEFAULT_PROXY_UDP_PORT)
     hub_listen_base = entry.options.get("hub_listen_base", DEFAULT_HUB_LISTEN_BASE)
+    broadcast_call_me = entry.options.get(CONF_BROADCAST_CALL_ME, DEFAULT_BROADCAST_CALL_ME)
 
     await hub.async_apply_new_settings(
         host=new_host,
         port=new_port,
         proxy_udp_port=proxy_udp_port,
         hub_listen_base=hub_listen_base,
+        broadcast_call_me=broadcast_call_me,
     )
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/sofabaton_x1s/config_flow.py
+++ b/custom_components/sofabaton_x1s/config_flow.py
@@ -20,6 +20,8 @@ from .const import (
     CONF_MDNS_VERSION,
     DEFAULT_PROXY_UDP_PORT,
     DEFAULT_HUB_LISTEN_BASE,
+    CONF_BROADCAST_CALL_ME,
+    DEFAULT_BROADCAST_CALL_ME,
     X1S_NO_THRESHOLD,
 )
 
@@ -119,13 +121,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             first = existing_entries[0]
             current_proxy_udp = first.options.get("proxy_udp_port", DEFAULT_PROXY_UDP_PORT)
             current_hub_listen_base = first.options.get("hub_listen_base", DEFAULT_HUB_LISTEN_BASE)
+            current_broadcast = first.options.get(CONF_BROADCAST_CALL_ME, DEFAULT_BROADCAST_CALL_ME)
         else:
             current_proxy_udp = DEFAULT_PROXY_UDP_PORT
             current_hub_listen_base = DEFAULT_HUB_LISTEN_BASE
+            current_broadcast = DEFAULT_BROADCAST_CALL_ME
 
         if user_input is not None:
             proxy_udp_port = user_input["proxy_udp_port"]
             hub_listen_base = user_input["hub_listen_base"]
+            broadcast_call_me = user_input.get(CONF_BROADCAST_CALL_ME, DEFAULT_BROADCAST_CALL_ME)
 
             # finish
             hub_info = self._chosen_hub
@@ -157,13 +162,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     "proxy_udp_port": proxy_udp_port,
                     "hub_listen_base": hub_listen_base,
                     CONF_MDNS_VERSION: version,
+                    CONF_BROADCAST_CALL_ME: broadcast_call_me,
                 },
             )
-            
+
         PORT_VALIDATOR = vol.All(int, vol.Range(min=1, max=65535))
         schema = vol.Schema({
             vol.Required("proxy_udp_port", default=current_proxy_udp): PORT_VALIDATOR,
             vol.Required("hub_listen_base", default=current_hub_listen_base): PORT_VALIDATOR,
+            vol.Optional(CONF_BROADCAST_CALL_ME, default=current_broadcast): bool,
         })
 
         return self.async_show_form(
@@ -326,6 +333,10 @@ class SofabatonOptionsFlowHandler(config_entries.OptionsFlow):
                 "hub_listen_base",
                 default=self.entry.options.get("hub_listen_base", DEFAULT_HUB_LISTEN_BASE),
             ): PORT_VALIDATOR,
+            vol.Optional(
+                CONF_BROADCAST_CALL_ME,
+                default=self.entry.options.get(CONF_BROADCAST_CALL_ME, DEFAULT_BROADCAST_CALL_ME),
+            ): bool,
         })
 
         return self.async_show_form(

--- a/custom_components/sofabaton_x1s/const.py
+++ b/custom_components/sofabaton_x1s/const.py
@@ -10,12 +10,15 @@ CONF_MDNS_TXT = "mdns_txt"
 CONF_MDNS_VERSION = "mdns_version"
 CONF_PROXY_ENABLED = "proxy_enabled"
 CONF_HEX_LOGGING_ENABLED = "hex_logging_enabled"
+CONF_BROADCAST_CALL_ME = "broadcast_call_me"
+CONF_IOS_ADVERTISING = CONF_BROADCAST_CALL_ME
 
 # X1S devices report a higher NO field in their mDNS TXT records
 X1S_NO_THRESHOLD = 20221120
 
 DEFAULT_PROXY_UDP_PORT = 9102
 DEFAULT_HUB_LISTEN_BASE = 8200
+DEFAULT_BROADCAST_CALL_ME = False
 
 PLATFORMS = ["select", "switch", "binary_sensor", "button", "sensor", "remote"]
 

--- a/custom_components/sofabaton_x1s/lib/call_me_demuxer.py
+++ b/custom_components/sofabaton_x1s/lib/call_me_demuxer.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import logging
+import socket
+import struct
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional, Tuple
+
+from .protocol_const import OP_CALL_ME, SYNC0, SYNC1
+
+log = logging.getLogger("x1proxy.call_me")
+
+
+def _sum8(b: bytes) -> int:
+    return sum(b) & 0xFF
+
+
+def _route_local_ip(peer_ip: str) -> str:
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect((peer_ip, 80))
+        return s.getsockname()[0]
+    except Exception:
+        return "127.0.0.1"
+    finally:
+        try:
+            s.close()
+        except Exception:
+            pass
+
+
+def _parse_mac_bytes(mac: Optional[str]) -> bytes:
+    if not mac or not isinstance(mac, str):
+        return b"\x00\x00\x00\x00\x00\x00"
+
+    cleaned = mac.replace(":", "").replace("-", "").strip()
+    if len(cleaned) != 12:
+        return b"\x00\x00\x00\x00\x00\x00"
+
+    try:
+        return bytes.fromhex(cleaned)
+    except ValueError:
+        return b"\x00\x00\x00\x00\x00\x00"
+
+
+@dataclass
+class CallMeRegistration:
+    key: str
+    name: str
+    mac: bytes
+    get_udp_port: Callable[[], int]
+    connect_handler: Callable[[Tuple[str, int]], None]
+    is_enabled: Callable[[], bool]
+
+
+class CallMeDemuxer:
+    def __init__(self, listen_port: int = 8102, *, throttle: float = 1.5, stop_delay: float = 30.0) -> None:
+        self.listen_port = listen_port
+        self.throttle = throttle
+        self.stop_delay = stop_delay
+
+        self._registrations: Dict[str, CallMeRegistration] = {}
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._sock: Optional[socket.socket] = None
+        self._last_sent: Dict[Tuple[str, int, str], float] = {}
+        self._stop_after: Optional[float] = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def register(self, registration: CallMeRegistration) -> Callable[[], None]:
+        with self._lock:
+            self._registrations[registration.key] = registration
+            if self._thread is None or not self._thread.is_alive():
+                self._start()
+
+        def _unregister() -> None:
+            self.unregister(registration.key)
+
+        return _unregister
+
+    def unregister(self, key: str) -> None:
+        with self._lock:
+            self._registrations.pop(key, None)
+            if not self._registrations:
+                self._stop.set()
+                self._close_sock()
+
+    def _start(self) -> None:
+        self._stop.clear()
+        self._stop_after = None
+        try:
+            self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            self._sock.bind(("", self.listen_port))
+        except OSError:
+            log.warning("[UDP] failed to bind broadcast listener on *:%d", self.listen_port, exc_info=True)
+            self._sock = None
+            return
+
+        self._thread = threading.Thread(target=self._loop, name="x1proxy-callme", daemon=True)
+        self._thread.start()
+        log.info("[UDP] broadcast CALL_ME demuxer listening on *:%d", self.listen_port)
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._close_sock()
+
+    def _close_sock(self) -> None:
+        if self._sock:
+            try:
+                self._sock.close()
+            except Exception:
+                pass
+            self._sock = None
+
+    # ------------------------------------------------------------------
+    # External notifications
+    # ------------------------------------------------------------------
+    def mark_client_connected(self) -> None:
+        # give the app a window to retry without keeping the port forever
+        self._stop_after = time.monotonic() + self.stop_delay
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    def _loop(self) -> None:
+        sock = self._sock
+        if sock is None:
+            return
+
+        while not self._stop.is_set():
+            if self._stop_after is not None and time.monotonic() >= self._stop_after:
+                log.info("[UDP] broadcast listener idle after client connect; stopping")
+                break
+
+            try:
+                pkt, (src_ip, src_port) = sock.recvfrom(2048)
+            except OSError:
+                break
+
+            if len(pkt) < 16 or pkt[0] != SYNC0 or pkt[1] != SYNC1:
+                continue
+            op = (pkt[2] << 8) | pkt[3]
+            if op != OP_CALL_ME:
+                continue
+
+            try:
+                app_ip = socket.inet_ntoa(pkt[10:14])
+                app_port = struct.unpack(">H", pkt[14:16])[0]
+            except Exception:
+                continue
+
+            self._handle_call_me(app_ip, app_port, src_ip, src_port)
+
+        self._close_sock()
+
+    def _handle_call_me(self, app_ip: str, app_port: int, src_ip: str, src_port: int) -> None:
+        now = time.time()
+        with self._lock:
+            regs = list(self._registrations.values())
+
+        for reg in regs:
+            if not reg.is_enabled():
+                continue
+
+            key = (app_ip, app_port, reg.key)
+            if now - self._last_sent.get(key, 0) < self.throttle:
+                continue
+
+            try:
+                reg.connect_handler((app_ip, app_port))
+            except Exception:
+                log.exception("[UDP] connect handler failed for %s", reg.name)
+
+            try:
+                udp_port = reg.get_udp_port()
+            except Exception:
+                log.exception("[UDP] failed to read udp port for %s", reg.name)
+                continue
+
+            if udp_port <= 0:
+                continue
+
+            my_ip = _route_local_ip(src_ip)
+            payload = reg.mac[:6].ljust(6, b"\x00") + socket.inet_aton(my_ip) + struct.pack(">H", udp_port)
+            frame = bytes([SYNC0, SYNC1, (OP_CALL_ME >> 8) & 0xFF, OP_CALL_ME & 0xFF]) + payload
+            frame += bytes([_sum8(frame)])
+
+            try:
+                if self._sock:
+                    self._sock.sendto(frame, (app_ip, app_port))
+                self._last_sent[key] = now
+                log.info(
+                    "[UDP] replied CALL_ME for %s -> app %s:%d (src %s:%d) advertising %s:%d",
+                    reg.name,
+                    app_ip,
+                    app_port,
+                    src_ip,
+                    src_port,
+                    my_ip,
+                    udp_port,
+                )
+            except Exception:
+                log.exception("[UDP] failed to send CALL_ME reply for %s", reg.name)
+
+
+_DEMUXER = CallMeDemuxer()
+
+
+def register_call_me_proxy(
+    *,
+    key: str,
+    name: str,
+    mac: Optional[str],
+    get_udp_port: Callable[[], int],
+    connect_handler: Callable[[Tuple[str, int]], None],
+    is_enabled: Callable[[], bool],
+) -> Callable[[], None]:
+    reg = CallMeRegistration(
+        key=key,
+        name=name,
+        mac=_parse_mac_bytes(mac),
+        get_udp_port=get_udp_port,
+        connect_handler=connect_handler,
+        is_enabled=is_enabled,
+    )
+    return _DEMUXER.register(reg)
+
+
+def notify_call_me_client_state(connected: bool) -> None:
+    if connected:
+        _DEMUXER.mark_client_connected()
+
+
+def stop_call_me_demuxer() -> None:
+    _DEMUXER.stop()

--- a/custom_components/sofabaton_x1s/lib/transport_bridge.py
+++ b/custom_components/sofabaton_x1s/lib/transport_bridge.py
@@ -170,6 +170,16 @@ class TransportBridge:
     def send_local(self, payload: bytes) -> None:
         self._local_to_hub.extend(payload)
 
+    def handle_app_call_me(self, app_addr: Tuple[str, int]) -> None:
+        if not self._proxy_enabled:
+            return
+        threading.Thread(
+            target=self._handle_app_session,
+            args=(app_addr,),
+            name="x1proxy-app-connect",
+            daemon=True,
+        ).start()
+
     # ------------------------------------------------------------------
     # Networking lifecycle
     # ------------------------------------------------------------------
@@ -289,12 +299,7 @@ class TransportBridge:
                 app_ip,
                 app_port,
             )
-            threading.Thread(
-                target=self._handle_app_session,
-                args=((app_ip, app_port),),
-                name="x1proxy-app-connect",
-                daemon=True,
-            ).start()
+            self.handle_app_call_me((app_ip, app_port))
 
     def _hub_guard_loop(self) -> None:
         while not self._stop.is_set():

--- a/custom_components/sofabaton_x1s/switch.py
+++ b/custom_components/sofabaton_x1s/switch.py
@@ -1,4 +1,3 @@
-# custom_components/sofabaton_x1s/switch.py
 from __future__ import annotations
 
 from homeassistant.components.switch import SwitchEntity
@@ -21,6 +20,7 @@ async def async_setup_entry(
     async_add_entities(
         [
             SofabatonProxySwitch(hub, entry),
+            SofabatonIosAdvertisingSwitch(hub, entry),
             SofabatonHexLoggingSwitch(hub, entry),
         ]
     )
@@ -55,6 +55,42 @@ class SofabatonProxySwitch(SwitchEntity):
     async def async_turn_off(self, **kwargs) -> None:
         await self._hub.async_set_proxy_enabled(False)
         self.async_write_ha_state()
+
+
+class SofabatonIosAdvertisingSwitch(SwitchEntity):
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.CONFIG  # ← this makes it show under "Configuration"
+
+    def __init__(self, hub: SofabatonHub, entry: ConfigEntry) -> None:
+        self._hub = hub
+        self._entry = entry
+        self._attr_unique_id = f"{entry.data[CONF_MAC]}_ios_advertising"
+        self._attr_name = f"{entry.data[CONF_NAME]} iOS advertising"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.data[CONF_MAC])},
+            name=self._entry.data[CONF_NAME],
+            model=get_hub_model(self._entry),
+        )
+
+    @property
+    def available(self) -> bool:
+        return self._hub.proxy_enabled
+
+    @property
+    def is_on(self) -> bool:
+        return self._hub.broadcast_call_me
+
+    async def async_turn_on(self, **kwargs) -> None:
+        await self._hub.async_set_ios_advertising(True)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        await self._hub.async_set_ios_advertising(False)
+        self.async_write_ha_state()
+
 
 class SofabatonHexLoggingSwitch(SwitchEntity):
     _attr_should_poll = False

--- a/custom_components/sofabaton_x1s/translations/en.json
+++ b/custom_components/sofabaton_x1s/translations/en.json
@@ -19,7 +19,8 @@
         "description": "These ports are used by the local proxy that emulates the hub. Most users can keep the defaults. Change them only if there is a conflict. Note that this setting currently applies to all configured hubs. The ports represents a base value, and the integration will try to find an open port within 32 ports of what you enter here.",
         "data": {
           "proxy_udp_port": "Proxy UDP base port",
-          "hub_listen_base": "Hub TCP listen base"
+          "hub_listen_base": "Hub TCP listen base",
+          "broadcast_call_me": "Enable iOS advertising (responds to CALL_ME on 8102)"
         }
       },
       "zeroconf_confirm": {
@@ -35,7 +36,8 @@
         "description": "{explain}",
         "data": {
           "proxy_udp_port": "Proxy UDP base port",
-          "hub_listen_base": "Hub TCP listen base"
+          "hub_listen_base": "Hub TCP listen base",
+          "broadcast_call_me": "Enable iOS advertising (responds to CALL_ME on 8102)"
         }
       }
     }


### PR DESCRIPTION
## Summary
- add a dedicated iOS advertising switch that toggles the CALL_ME broadcast listener
- make the advertising switch unavailable when the proxy is disabled and wire it through hub/proxy
- update option text to clarify the fixed 8102 broadcast port

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924ad9139bc832db3b675668d828b37)