### PR TITLE
Handle iOS discovery pings

### DIFF
--- a/custom_components/sofabaton_x1s/lib/call_me_demuxer.py
+++ b/custom_components/sofabaton_x1s/lib/call_me_demuxer.py
@@ -152,13 +152,8 @@ class CallMeDemuxer:
                 break
 
             pkt_len = len(pkt)
-            if pkt_len < 16 or pkt[0] != SYNC0 or pkt[1] != SYNC1:
-                log.debug(
-                    "[UDP] ignored packet len=%d from %s:%d (sync/size)",
-                    pkt_len,
-                    src_ip,
-                    src_port,
-                )
+            if pkt_len < 4 or pkt[0] != SYNC0 or pkt[1] != SYNC1:
+                self._handle_ios_discovery(src_ip, src_port)
                 continue
             op = (pkt[2] << 8) | pkt[3]
             if op != OP_CALL_ME:
@@ -167,26 +162,22 @@ class CallMeDemuxer:
                 )
                 continue
 
-            try:
-                app_ip = socket.inet_ntoa(pkt[10:14])
-                app_port = struct.unpack(">H", pkt[14:16])[0]
-            except Exception:
-                log.debug(
-                    "[UDP] failed to parse CALL_ME from %s:%d (len=%d)",
+            app_ip, app_port, advertised = self._extract_app_endpoint(pkt, src_ip, src_port)
+
+            if advertised:
+                log.info(
+                    "[UDP] CALL_ME broadcast from %s:%d advertising app %s:%d",
                     src_ip,
                     src_port,
-                    pkt_len,
-                    exc_info=True,
+                    app_ip,
+                    app_port,
                 )
-                continue
-
-            log.info(
-                "[UDP] CALL_ME broadcast from %s:%d advertising app %s:%d",
-                src_ip,
-                src_port,
-                app_ip,
-                app_port,
-            )
+            else:
+                log.info(
+                    "[UDP] CALL_ME broadcast from %s:%d (no payload; replying to source)",
+                    src_ip,
+                    src_port,
+                )
             self._handle_call_me(app_ip, app_port, src_ip, src_port)
 
         self._close_sock()
@@ -222,26 +213,109 @@ class CallMeDemuxer:
                 continue
 
             my_ip = _route_local_ip(src_ip)
-            payload = reg.mac[:6].ljust(6, b"\x00") + socket.inet_aton(my_ip) + struct.pack(">H", udp_port)
-            frame = bytes([SYNC0, SYNC1, (OP_CALL_ME >> 8) & 0xFF, OP_CALL_ME & 0xFF]) + payload
-            frame += bytes([_sum8(frame)])
+            frame = self._build_call_me_frame(reg.mac, my_ip, udp_port)
+            self._send_frame(frame, (app_ip, app_port), key, now, reg.name, src_ip, src_port, advertised_ip=my_ip, advertised_port=udp_port)
+
+    def _handle_ios_discovery(self, src_ip: str, src_port: int) -> None:
+        now = time.time()
+        with self._lock:
+            regs = list(self._registrations.values())
+
+        for reg in regs:
+            if not reg.is_enabled():
+                log.debug("[UDP] skipping %s (disabled)", reg.name)
+                continue
 
             try:
-                if self._sock:
-                    self._sock.sendto(frame, (app_ip, app_port))
-                self._last_sent[key] = now
-                log.info(
-                    "[UDP] replied CALL_ME for %s -> app %s:%d (src %s:%d) advertising %s:%d",
-                    reg.name,
-                    app_ip,
-                    app_port,
-                    src_ip,
-                    src_port,
-                    my_ip,
-                    udp_port,
+                udp_port = reg.get_udp_port()
+            except Exception:
+                log.exception("[UDP] failed to read udp port for %s", reg.name)
+                continue
+
+            if udp_port <= 0:
+                log.info("[UDP] skipping iOS discovery reply for %s (invalid port %d)", reg.name, udp_port)
+                continue
+
+            my_ip = _route_local_ip(src_ip)
+            frame = self._build_call_me_frame(reg.mac, my_ip, udp_port)
+            key = (src_ip, src_port, f"discovery-{reg.key}")
+            self._send_frame(
+                frame,
+                (src_ip, src_port),
+                key,
+                now,
+                reg.name,
+                src_ip,
+                src_port,
+                advertised_ip=my_ip,
+                advertised_port=udp_port,
+                log_prefix="iOS discovery",
+            )
+
+    @staticmethod
+    def _extract_app_endpoint(
+        pkt: bytes, src_ip: str, src_port: int
+    ) -> Tuple[str, int, bool]:
+        """Extract the app endpoint from a CALL_ME broadcast.
+
+        The app may omit the payload (yielding a 5-byte frame). In that case we
+        fall back to replying to the source IP/port that sent the broadcast.
+        """
+
+        if len(pkt) >= 16:
+            try:
+                return (
+                    socket.inet_ntoa(pkt[10:14]),
+                    struct.unpack(">H", pkt[14:16])[0],
+                    True,
                 )
             except Exception:
-                log.exception("[UDP] failed to send CALL_ME reply for %s", reg.name)
+                log.debug("[UDP] failed to parse CALL_ME payload", exc_info=True)
+
+        return src_ip, src_port, False
+
+    @staticmethod
+    def _build_call_me_frame(mac: bytes, my_ip: str, udp_port: int) -> bytes:
+        payload = mac[:6].ljust(6, b"\x00") + socket.inet_aton(my_ip) + struct.pack(">H", udp_port)
+        frame = bytes([SYNC0, SYNC1, (OP_CALL_ME >> 8) & 0xFF, OP_CALL_ME & 0xFF]) + payload
+        frame += bytes([_sum8(frame)])
+        return frame
+
+    def _send_frame(
+        self,
+        frame: bytes,
+        dest: Tuple[str, int],
+        key: Tuple[str, int, str],
+        now: float,
+        reg_name: str,
+        src_ip: str,
+        src_port: int,
+        *,
+        advertised_ip: str,
+        advertised_port: int,
+        log_prefix: str = "CALL_ME",
+    ) -> None:
+        if now - self._last_sent.get(key, 0) < self.throttle:
+            log.debug("[UDP] throttling %s reply for %s", log_prefix, reg_name)
+            return
+
+        try:
+            if self._sock:
+                self._sock.sendto(frame, dest)
+            self._last_sent[key] = now
+            log.info(
+                "[UDP] replied %s for %s -> app %s:%d (src %s:%d) advertising %s:%d",
+                log_prefix,
+                reg_name,
+                dest[0],
+                dest[1],
+                src_ip,
+                src_port,
+                advertised_ip,
+                advertised_port,
+            )
+        except Exception:
+            log.exception("[UDP] failed to send %s reply for %s", log_prefix, reg_name)
 
 
 _DEMUXER = CallMeDemuxer()

--- a/custom_components/sofabaton_x1s/lib/transport_bridge.py
+++ b/custom_components/sofabaton_x1s/lib/transport_bridge.py
@@ -280,7 +280,8 @@ class TransportBridge:
                 pkt, (src_ip, src_port) = sock.recvfrom(2048)
             except OSError:
                 break
-            if len(pkt) < 16 or pkt[0] != SYNC0 or pkt[1] != SYNC1:
+            pkt_len = len(pkt)
+            if pkt_len < 4 or pkt[0] != SYNC0 or pkt[1] != SYNC1:
                 continue
             op = (pkt[2] << 8) | pkt[3]
             if op != OP_CALL_ME:
@@ -288,17 +289,25 @@ class TransportBridge:
             try:
                 app_ip = socket.inet_ntoa(pkt[10:14])
                 app_port = struct.unpack(">H", pkt[14:16])[0]
+                advertised = True
             except Exception:
-                continue
+                app_ip, app_port, advertised = src_ip, src_port, False
             if not self._proxy_enabled:
                 continue
-            log.info(
-                "[UDP] APP CALL_ME from %s:%d -> app tcp %s:%d",
-                src_ip,
-                src_port,
-                app_ip,
-                app_port,
-            )
+            if advertised:
+                log.info(
+                    "[UDP] APP CALL_ME from %s:%d -> app tcp %s:%d",
+                    src_ip,
+                    src_port,
+                    app_ip,
+                    app_port,
+                )
+            else:
+                log.info(
+                    "[UDP] APP CALL_ME from %s:%d (no payload; replying to source)",
+                    src_ip,
+                    src_port,
+                )
             self.handle_app_call_me((app_ip, app_port))
 
     def _hub_guard_loop(self) -> None:

--- a/tests/test_call_me_demuxer.py
+++ b/tests/test_call_me_demuxer.py
@@ -1,0 +1,97 @@
+import socket
+import struct
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _ensure_stub_package(name: str, path: Path) -> None:
+    if name in sys.modules:
+        return
+    module = types.ModuleType(name)
+    module.__path__ = [str(path)]
+    sys.modules[name] = module
+
+
+import types
+
+
+_ensure_stub_package("custom_components", ROOT / "custom_components")
+_ensure_stub_package("custom_components.sofabaton_x1s", ROOT / "custom_components" / "sofabaton_x1s")
+_ensure_stub_package("custom_components.sofabaton_x1s.lib", ROOT / "custom_components" / "sofabaton_x1s" / "lib")
+
+from custom_components.sofabaton_x1s.lib.call_me_demuxer import CallMeDemuxer, CallMeRegistration
+from custom_components.sofabaton_x1s.lib.protocol_const import OP_CALL_ME, SYNC0, SYNC1
+
+
+def _frame(payload: bytes) -> bytes:
+    frame = bytes([SYNC0, SYNC1, (OP_CALL_ME >> 8) & 0xFF, OP_CALL_ME & 0xFF]) + payload
+    checksum = sum(frame) & 0xFF
+    return frame + bytes([checksum])
+
+
+def test_extract_app_endpoint_from_payload():
+    payload = b"\xAA\xBB\xCC\xDD\xEE\xFF" + socket.inet_aton("1.2.3.4") + struct.pack(">H", 9000)
+    pkt = _frame(payload)
+
+    app_ip, app_port, advertised = CallMeDemuxer._extract_app_endpoint(pkt, "10.0.0.2", 8100)
+
+    assert advertised is True
+    assert app_ip == "1.2.3.4"
+    assert app_port == 9000
+
+
+def test_extract_app_endpoint_without_payload_falls_back_to_source():
+    pkt = _frame(b"")
+
+    app_ip, app_port, advertised = CallMeDemuxer._extract_app_endpoint(pkt, "10.0.0.2", 8100)
+
+    assert advertised is False
+    assert (app_ip, app_port) == ("10.0.0.2", 8100)
+
+
+def test_build_call_me_frame_contains_expected_parts():
+    frame = CallMeDemuxer._build_call_me_frame(b"\xAA\xBB\xCC\xDD\xEE\xFF", "10.0.0.10", 9000)
+
+    # sync + opcode + mac + ip + port + checksum
+    assert frame[:4] == bytes([SYNC0, SYNC1, (OP_CALL_ME >> 8) & 0xFF, OP_CALL_ME & 0xFF])
+    assert frame[4:10] == b"\xAA\xBB\xCC\xDD\xEE\xFF"
+    assert frame[10:14] == socket.inet_aton("10.0.0.10")
+    assert frame[14:16] == struct.pack(">H", 9000)
+    assert len(frame) == 17
+
+
+def test_ios_discovery_reply_uses_source_endpoint_and_throttle():
+    class _FakeSocket:
+        def __init__(self) -> None:
+            self.sent = []
+
+        def sendto(self, data: bytes, dest):
+            self.sent.append((data, dest))
+
+    demuxer = CallMeDemuxer(throttle=10.0)
+    fake_sock = _FakeSocket()
+    demuxer._sock = fake_sock
+    demuxer._registrations = {
+        "k": CallMeRegistration(
+            key="k",
+            name="Test",
+            mac=b"\x01\x02\x03\x04\x05\x06",
+            get_udp_port=lambda: 8200,
+            connect_handler=lambda _addr: None,
+            is_enabled=lambda: True,
+        )
+    }
+
+    demuxer._handle_ios_discovery("192.0.2.1", 8100)
+
+    assert len(fake_sock.sent) == 1
+    frame, dest = fake_sock.sent[0]
+    assert dest == ("192.0.2.1", 8100)
+    # second call throttles
+    demuxer._handle_ios_discovery("192.0.2.1", 8100)
+    assert len(fake_sock.sent) == 1


### PR DESCRIPTION
## Summary
- respond to iOS discovery pings by advertising the proxy endpoint instead of ignoring short packets
- reuse a shared CALL_ME frame builder/sender for both discovery replies and normal CALL_ME handling
- add tests covering CALL_ME frame construction and discovery reply throttling

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924babcbbd4832d8dcfa3272a47a8dc)