### PR TITLE
Re-register notify demuxer after client disconnects

### DIFF
--- a/custom_components/sofabaton_x1s/lib/transport_bridge.py
+++ b/custom_components/sofabaton_x1s/lib/transport_bridge.py
@@ -524,6 +524,8 @@ class TransportBridge:
     def _notify_client_state(self, connected: bool) -> None:
         if connected:
             self._stop_notify_listener()
+        elif self._broadcast_listener_enabled and self._proxy_enabled:
+            self._register_demuxer()
         for cb in self._client_state_cbs:
             try:
                 cb(connected)


### PR DESCRIPTION
## Summary
- re-register the NOTIFY listener when the client disconnects so broadcast replies continue to work

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924d5c26b60832dab0be2fac8a9e8b5)