### PR TITLE
Broadcast NOTIFY_ME replies and mimic hub discovery frame

### DIFF
--- a/custom_components/sofabaton_x1s/lib/notify_demuxer.py
+++ b/custom_components/sofabaton_x1s/lib/notify_demuxer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import ipaddress
 import socket
 import struct
 import threading
@@ -13,6 +14,7 @@ from .protocol_const import SYNC0, SYNC1
 log = logging.getLogger("x1proxy.notify")
 
 NOTIFY_ME_PAYLOAD = bytes.fromhex("a55a00c1c0")
+NOTIFY_REPLY_OPCODE = 0x1DC2
 
 
 def _sum8(b: bytes) -> int:
@@ -31,6 +33,39 @@ def _route_local_ip(peer_ip: str) -> str:
             s.close()
         except Exception:
             pass
+
+
+def _broadcast_ip(peer_ip: str) -> str:
+    try:
+        addr = ipaddress.ip_address(peer_ip)
+        network = ipaddress.ip_network(f"{addr}/24", strict=False)
+        return str(network.broadcast_address)
+    except ValueError:
+        return "255.255.255.255"
+
+
+def _parse_int(raw: Optional[str]) -> int:
+    if raw is None:
+        return 0
+    try:
+        return int(str(raw), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _parse_fw_version(raw: Optional[str]) -> tuple[int, int, int]:
+    if not raw:
+        return 0, 0, 0
+    parts = str(raw).split(".")
+    out = []
+    for p in parts[:3]:
+        try:
+            out.append(int(p, 0) & 0xFF)
+        except ValueError:
+            out.append(0)
+    while len(out) < 3:
+        out.append(0)
+    return out[0], out[1], out[2]
 
 
 @dataclass(frozen=True)
@@ -152,26 +187,26 @@ class NotifyDemuxer:
                 if now - last < 2.0:
                     continue
 
-                reply = self._build_notify_reply(reg, src_ip)
+                reply = self._build_notify_reply(reg)
                 if reply is None:
                     continue
 
                 self._last_reply[key] = now
+                dest_ip = _broadcast_ip(src_ip)
                 log.info(
-                    "[DEMUX] NOTIFY_ME from %s:%d -> proxy=%s CALL_ME=%d",
+                    "[DEMUX] NOTIFY_ME from %s:%d -> proxy=%s CALL_ME=%d broadcast=%s",
                     src_ip,
                     src_port,
                     reg.proxy_id,
                     reg.call_me_port,
+                    dest_ip,
                 )
                 try:
-                    sock.sendto(reply, (src_ip, src_port))
+                    sock.sendto(reply, (dest_ip, reg.call_me_port))
                 except OSError:
                     log.exception("[DEMUX] failed to send NOTIFY_ME reply for %s", reg.proxy_id)
 
-    def _build_notify_reply(
-        self, reg: NotifyRegistration, app_ip: str
-    ) -> Optional[bytes]:
+    def _build_notify_reply(self, reg: NotifyRegistration) -> Optional[bytes]:
         try:
             mac_raw = (
                 reg.mdns_txt.get("MAC")
@@ -191,21 +226,45 @@ class NotifyDemuxer:
         else:
             mac_bytes = mac_bytes[:6]
 
-        try:
-            advertised_ip = _route_local_ip(app_ip)
-            ip_bytes = socket.inet_aton(advertised_ip)
-        except OSError:
-            return None
+        model = _parse_int(reg.mdns_txt.get("MODEL") or reg.mdns_txt.get("model"))
+        model_bytes = struct.pack(">H", model & 0xFFFF)
 
-        payload = mac_bytes + ip_bytes + struct.pack(">H", reg.call_me_port)
-        frame = bytes([SYNC0, SYNC1, 0x00, 0xC2]) + payload
+        build_raw = _parse_int(reg.mdns_txt.get("BUILD") or reg.mdns_txt.get("build"))
+        build_bytes = struct.pack(">I", build_raw & 0xFFFFFFFF)
+
+        fw_major, fw_minor, fw_patch = _parse_fw_version(
+            reg.mdns_txt.get("FW")
+            or reg.mdns_txt.get("fw")
+            or reg.mdns_txt.get("version")
+            or reg.mdns_txt.get("ver")
+        )
+
+        name = (
+            reg.mdns_txt.get("NAME")
+            or reg.mdns_txt.get("name")
+            or reg.mdns_txt.get("Name")
+            or "X1 Hub"
+        ).encode("utf-8")
+
+        payload = (
+            mac_bytes
+            + model_bytes
+            + build_bytes
+            + bytes([fw_major, fw_minor, fw_patch])
+            + name
+        )
+        frame = bytes([SYNC0, SYNC1, NOTIFY_REPLY_OPCODE >> 8, NOTIFY_REPLY_OPCODE & 0xFF]) + payload
         frame += bytes([_sum8(frame)])
         log.info(
-            "[DEMUX][REPLY] proxy=%s host=%s:%d mac=%s",
+            "[DEMUX][REPLY] proxy=%s model=0x%04x build=%08x fw=%d.%d.%d mac=%s name=%s",
             reg.proxy_id,
-            socket.inet_ntoa(ip_bytes),
-            reg.call_me_port,
+            model,
+            build_raw,
+            fw_major,
+            fw_minor,
+            fw_patch,
             mac_bytes.hex(":"),
+            name.decode("utf-8", "ignore"),
         )
         return frame
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+import sys
+import types
+from pathlib import Path
+
+
+def _install_homeassistant_stubs() -> None:
+    ha = types.ModuleType("homeassistant")
+    sys.modules.setdefault("homeassistant", ha)
+
+    config_entries = types.ModuleType("homeassistant.config_entries")
+
+    class ConfigEntry:  # pragma: no cover - only used as stub
+        pass
+
+    config_entries.ConfigEntry = ConfigEntry
+    sys.modules.setdefault("homeassistant.config_entries", config_entries)
+
+    core = types.ModuleType("homeassistant.core")
+
+    class HomeAssistant:  # pragma: no cover - only used as stub
+        pass
+
+    class ServiceCall:  # pragma: no cover - only used as stub
+        pass
+
+    core.HomeAssistant = HomeAssistant
+    core.ServiceCall = ServiceCall
+    sys.modules.setdefault("homeassistant.core", core)
+
+    helpers = types.ModuleType("homeassistant.helpers")
+    sys.modules.setdefault("homeassistant.helpers", helpers)
+
+    device_registry = types.ModuleType("homeassistant.helpers.device_registry")
+    device_registry.async_get = lambda hass=None: None
+    sys.modules.setdefault("homeassistant.helpers.device_registry", device_registry)
+
+    entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
+    entity_registry.async_get = lambda hass=None: None
+    sys.modules.setdefault("homeassistant.helpers.entity_registry", entity_registry)
+
+
+_install_homeassistant_stubs()
+
+# Ensure custom_components is importable when running tests directly
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_notify_demuxer.py
+++ b/tests/test_notify_demuxer.py
@@ -1,0 +1,29 @@
+from custom_components.sofabaton_x1s.lib.notify_demuxer import (
+    NotifyDemuxer,
+    NotifyRegistration,
+    _broadcast_ip,
+)
+
+
+def test_build_notify_reply_matches_capture():
+    mdns_txt = {
+        "MAC": "e2:6a:44:86:1b:45",
+        "MODEL": "0x6402",
+        "BUILD": "0x20221120",
+        "FW": "5.1.0",
+        "NAME": "Souterrain hub",
+    }
+    reg = NotifyRegistration("proxy", "192.168.2.151", mdns_txt, 8100)
+
+    demuxer = NotifyDemuxer()
+    frame = demuxer._build_notify_reply(reg)
+
+    assert frame is not None
+    assert frame.hex() == (
+        "a55a1dc2e26a44861b45640220221120050100536f757465727261696e20687562be"
+    )
+
+
+def test_broadcast_ip():
+    assert _broadcast_ip("192.168.2.151") == "192.168.2.255"
+    assert _broadcast_ip("invalid") == "255.255.255.255"


### PR DESCRIPTION
## Summary
- send NOTIFY_ME replies as broadcast frames that mirror the captured hub discovery payload
- parse model/build/fw/name data from mDNS TXT records when constructing the reply
- add unit tests (with Home Assistant stubs) covering the broadcast IP calculation and reply frame bytes

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924d9a91638832d877428dfb38018a0)