### PR TITLE
Adjust NOTIFY_ME broadcast port and payload

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+import sys
+import types
+from pathlib import Path
+
+
+def _install_homeassistant_stubs() -> None:
+    ha = types.ModuleType("homeassistant")
+    sys.modules.setdefault("homeassistant", ha)
+
+    config_entries = types.ModuleType("homeassistant.config_entries")
+
+    class ConfigEntry:  # pragma: no cover - only used as stub
+        pass
+
+    config_entries.ConfigEntry = ConfigEntry
+    sys.modules.setdefault("homeassistant.config_entries", config_entries)
+
+    core = types.ModuleType("homeassistant.core")
+
+    class HomeAssistant:  # pragma: no cover - only used as stub
+        pass
+
+    class ServiceCall:  # pragma: no cover - only used as stub
+        pass
+
+    core.HomeAssistant = HomeAssistant
+    core.ServiceCall = ServiceCall
+    sys.modules.setdefault("homeassistant.core", core)
+
+    helpers = types.ModuleType("homeassistant.helpers")
+    sys.modules.setdefault("homeassistant.helpers", helpers)
+
+    device_registry = types.ModuleType("homeassistant.helpers.device_registry")
+    device_registry.async_get = lambda hass=None: None
+    sys.modules.setdefault("homeassistant.helpers.device_registry", device_registry)
+
+    entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
+    entity_registry.async_get = lambda hass=None: None
+    sys.modules.setdefault("homeassistant.helpers.entity_registry", entity_registry)
+
+
+_install_homeassistant_stubs()
+
+# Ensure custom_components is importable when running tests directly
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_notify_demuxer.py
+++ b/tests/test_notify_demuxer.py
@@ -1,0 +1,64 @@
+import threading
+
+from custom_components.sofabaton_x1s.lib.notify_demuxer import (
+    NOTIFY_ME_PAYLOAD,
+    NotifyDemuxer,
+    NotifyRegistration,
+    _broadcast_ip,
+)
+
+
+def test_build_notify_reply_matches_capture():
+    mdns_txt = {
+        "MAC": "e2:6a:44:86:1b:45",
+        "MODEL": "0x6402",
+        "BUILD": "0x20221120",
+        "FW": "5.1.0",
+        "NAME": "Souterrain hub",
+    }
+    reg = NotifyRegistration("proxy", "192.168.2.151", mdns_txt, 8100)
+
+    demuxer = NotifyDemuxer()
+    frame = demuxer._build_notify_reply(reg)
+
+    assert frame is not None
+    assert frame.hex() == (
+        "a55a1de26a44861b4545640220221120050100536f757465727261696e20687562be"
+    )
+
+
+def test_broadcast_ip():
+    assert _broadcast_ip("192.168.2.151") == "192.168.2.255"
+    assert _broadcast_ip("invalid") == "255.255.255.255"
+
+
+def test_notify_me_reply_targets_source_port():
+    mdns_txt = {
+        "MAC": "e2:6a:44:86:1b:45",
+        "NAME": "Souterrain hub",
+    }
+    reg = NotifyRegistration("proxy", "192.168.2.151", mdns_txt, 8100)
+
+    demuxer = NotifyDemuxer()
+    demuxer._registrations = {"proxy": reg}
+    demuxer._stop_event = threading.Event()
+
+    class FakeSocket:
+        def __init__(self) -> None:
+            self.sent = []
+            self.recv_called = False
+
+        def recvfrom(self, _max: int):
+            if self.recv_called:
+                raise OSError()
+            self.recv_called = True
+            return NOTIFY_ME_PAYLOAD, ("192.168.2.10", 12345)
+
+        def sendto(self, data: bytes, addr):
+            self.sent.append((data, addr))
+
+    demuxer._sock = FakeSocket()
+    demuxer._notify_loop()
+
+    assert demuxer._sock.sent
+    assert demuxer._sock.sent[0][1] == ("192.168.2.255", 12345)


### PR DESCRIPTION
## Summary
- broadcast NOTIFY_ME replies to the source UDP port instead of the registered CALL_ME port
- rebuild the NOTIFY_ME reply to mirror the captured hub payload structure with fixed version block and padded name
- add regression coverage for the new payload bytes and broadcast port selection

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924d9a91638832d877428dfb38018a0)