### PR TITLE
Send NOTIFY_ME replies from CALL_ME port

### DIFF
--- a/custom_components/sofabaton_x1s/lib/notify_demuxer.py
+++ b/custom_components/sofabaton_x1s/lib/notify_demuxer.py
@@ -171,10 +171,13 @@ class NotifyDemuxer:
                     reg.call_me_port,
                     dest_ip,
                 )
-                try:
-                    sock.sendto(reply, (dest_ip, src_port))
-                except OSError:
-                    log.exception("[DEMUX] failed to send NOTIFY_ME reply for %s", reg.proxy_id)
+                if not self._send_reply_from_call_me_port(reply, dest_ip, src_port, reg):
+                    try:
+                        sock.sendto(reply, (dest_ip, src_port))
+                    except OSError:
+                        log.exception(
+                            "[DEMUX] failed to send NOTIFY_ME reply for %s", reg.proxy_id
+                        )
 
     def _build_notify_reply(self, reg: NotifyRegistration) -> Optional[bytes]:
         try:
@@ -224,6 +227,53 @@ class NotifyDemuxer:
             name.decode("utf-8", "ignore"),
         )
         return frame
+
+    def _send_reply_from_call_me_port(
+        self, reply: bytes, dest_ip: str, dest_port: int, reg: NotifyRegistration
+    ) -> bool:
+        """Try to send NOTIFY_ME reply from the port apps should CALL_ME back on."""
+
+        reuseport = getattr(socket, "SO_REUSEPORT", None)
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            if reuseport is not None:
+                try:
+                    s.setsockopt(socket.SOL_SOCKET, reuseport, 1)
+                except OSError:
+                    pass
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            s.bind(("0.0.0.0", reg.call_me_port))
+        except OSError:
+            log.warning(
+                "[DEMUX] failed to bind CALL_ME reply socket on *:%d; using default port",
+                reg.call_me_port,
+            )
+            try:
+                s.close()
+            except Exception:
+                pass
+            return False
+
+        try:
+            s.sendto(reply, (dest_ip, dest_port))
+            log.info(
+                "[DEMUX] sent NOTIFY_ME reply for %s from CALL_ME port %d",
+                reg.proxy_id,
+                reg.call_me_port,
+            )
+            return True
+        except OSError:
+            log.exception(
+                "[DEMUX] failed to send NOTIFY_ME reply for %s from CALL_ME port",
+                reg.proxy_id,
+            )
+            return False
+        finally:
+            try:
+                s.close()
+            except Exception:
+                pass
 
 
 _GLOBAL_DEMUXER: Optional[NotifyDemuxer] = None

--- a/custom_components/sofabaton_x1s/lib/transport_bridge.py
+++ b/custom_components/sofabaton_x1s/lib/transport_bridge.py
@@ -254,6 +254,12 @@ class TransportBridge:
     def _open_udp_listener(self) -> socket.socket:
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        reuseport = getattr(socket, "SO_REUSEPORT", None)
+        if reuseport is not None:
+            try:
+                s.setsockopt(socket.SOL_SOCKET, reuseport, 1)
+            except OSError:
+                pass
 
         base = self.proxy_udp_port
         last_err: Optional[Exception] = None


### PR DESCRIPTION
## Summary
- send NOTIFY_ME replies from the advertised CALL_ME port when possible
- allow the CALL_ME listener socket to share ports by enabling SO_REUSEPORT
- fall back to the original demuxer socket if binding the CALL_ME port fails

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924ecb04ed4832d9d2fddf77b97adf6)