### PR TITLE
Adjust notify broadcast behavior

### DIFF
--- a/custom_components/sofabaton_x1s/lib/notify_demuxer.py
+++ b/custom_components/sofabaton_x1s/lib/notify_demuxer.py
@@ -13,6 +13,7 @@ from .protocol_const import SYNC0, SYNC1
 log = logging.getLogger("x1proxy.notify")
 
 NOTIFY_ME_PAYLOAD = bytes.fromhex("a55a00c1c0")
+BROADCAST_LISTEN_PORT = 8100
 
 
 def _route_local_ip(peer_ip: str) -> str:
@@ -184,7 +185,7 @@ class NotifyDemuxer:
                     dest_ip,
                 )
                 try:
-                    sock.sendto(reply, (dest_ip, src_port))
+                    sock.sendto(reply, (dest_ip, BROADCAST_LISTEN_PORT))
                 except OSError:
                     log.exception("[DEMUX] failed to send NOTIFY_ME reply for %s", reg.proxy_id)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,20 @@ def _install_homeassistant_stubs() -> None:
     helpers = types.ModuleType("homeassistant.helpers")
     sys.modules.setdefault("homeassistant.helpers", helpers)
 
+    dispatcher = types.ModuleType("homeassistant.helpers.dispatcher")
+    dispatcher.async_dispatcher_send = lambda hass=None, signal=None, *args, **kwargs: None
+    dispatcher.async_dispatcher_connect = lambda hass=None, signal=None, target=None: None
+    dispatcher.dispatcher_send = lambda *args, **kwargs: None
+    dispatcher.dispatcher_connect = lambda *args, **kwargs: None
+    sys.modules.setdefault("homeassistant.helpers.dispatcher", dispatcher)
+
+    exceptions = types.ModuleType("homeassistant.exceptions")
+    class HomeAssistantError(Exception):
+        pass
+
+    exceptions.HomeAssistantError = HomeAssistantError
+    sys.modules.setdefault("homeassistant.exceptions", exceptions)
+
     device_registry = types.ModuleType("homeassistant.helpers.device_registry")
     device_registry.async_get = lambda hass=None: None
     sys.modules.setdefault("homeassistant.helpers.device_registry", device_registry)

--- a/tests/test_notify_demuxer.py
+++ b/tests/test_notify_demuxer.py
@@ -61,4 +61,4 @@ def test_notify_me_reply_targets_source_port():
     demuxer._notify_loop()
 
     assert demuxer._sock.sent
-    assert demuxer._sock.sent[0][1] == ("192.168.2.255", 12345)
+    assert demuxer._sock.sent[0][1] == ("192.168.2.255", 8100)

--- a/tests/test_transport_bridge.py
+++ b/tests/test_transport_bridge.py
@@ -1,0 +1,71 @@
+from custom_components.sofabaton_x1s.lib import transport_bridge
+from custom_components.sofabaton_x1s.lib.notify_demuxer import BROADCAST_LISTEN_PORT
+from custom_components.sofabaton_x1s.lib.transport_bridge import (
+    CONNECT_READY_BROADCAST,
+    TransportBridge,
+)
+
+
+def test_connect_beacon_targets_broadcast_port(monkeypatch):
+    sent = []
+
+    class FakeSocket:
+        def __init__(self, *_args, **_kwargs):
+            self.closed = False
+
+        def setsockopt(self, *_args, **_kwargs):
+            pass
+
+        def sendto(self, data, addr):
+            sent.append((data, addr))
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(transport_bridge.socket, "socket", lambda *a, **k: FakeSocket())
+
+    bridge = TransportBridge(
+        "192.168.2.10", 8102, 9102, 8200, proxy_id="proxy", mdns_instance="proxy", mdns_txt={}
+    )
+    bridge._emit_connect_ready_beacon("192.168.2.15")
+
+    assert sent
+    payload, addr = sent[0]
+    assert payload == CONNECT_READY_BROADCAST
+    assert addr == ("192.168.2.255", BROADCAST_LISTEN_PORT)
+
+
+def test_notify_listener_stops_when_connecting(monkeypatch):
+    bridge = TransportBridge(
+        "192.168.2.10", 8102, 9102, 8200, proxy_id="proxy", mdns_instance="proxy", mdns_txt={}
+    )
+    stopped = False
+
+    def fake_stop() -> None:
+        nonlocal stopped
+        stopped = True
+
+    bridge._stop_notify_listener = fake_stop  # type: ignore[assignment]
+
+    class FailingSocket:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def settimeout(self, *_args, **_kwargs):
+            pass
+
+        def connect(self, *_args, **_kwargs):
+            assert stopped
+            raise OSError("connect failed")
+
+        def setsockopt(self, *_args, **_kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(transport_bridge.socket, "socket", lambda *a, **k: FailingSocket())
+
+    bridge._handle_app_session(("192.168.2.20", 1234))
+
+    assert stopped


### PR DESCRIPTION
## Summary
- send NOTIFY_ME replies to the fixed hub broadcast port and broadcast a single connect-ready beacon
- stop repeating notify replies as soon as a TCP client connection begins
- expand test coverage and Home Assistant stubs for the updated broadcast behavior

## Testing
- pytest tests/test_notify_demuxer.py tests/test_transport_bridge.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e1610aec832da288c1781c106167)