### PR TITLE
Unify CALL_ME/NOTIFY_ME handling on single UDP port

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,15 @@ This integration follows the same 3-step flow as the official Sofabaton app:
 So, if you use VLANs / firewalls:
 
 - allow **mDNS** from hub → HA (or forward it)
-- allow **UDP** from HA → hub on the Sofabaton port (`8102` i think is the standard port on these devices)
+- allow **UDP** from HA → hub on the Sofabaton port (`8102` is the standard port on these devices)
 - allow **TCP** from hub → HA on the proxy port (the one you configured in the integration)
 
 If discovery works but the entities never go “connected to hub”, it’s usually that last rule: the hub cannot open the TCP back to HA.
 Also keep in mind that as soon as a client is connected to the physical hub, the hub stops mDNS advertising. So if this integration is connected and running with "proxy" disabled, the official app will not find it. And vice versa, the integration cannot see the hub if the official app is connected directly to it.
+
+### Upgrading note: single CALL_ME/NOTIFY_ME listener on 8102
+
+The proxy now uses one UDP listener for both CALL_ME and NOTIFY_ME, shared across all configured hubs. New installs default this listener to `8102` so Android and iOS discovery both work. If you previously overrode the **Proxy UDP base port** (for example, to `9102`), consider changing it back to `8102`. Using a different UDP port applies to all hubs and may prevent the iOS app from discovering the proxy.
 
 ---
 

--- a/custom_components/sofabaton_x1s/config_flow.py
+++ b/custom_components/sofabaton_x1s/config_flow.py
@@ -180,14 +180,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=schema,
             description_placeholders={
                 "explain": (
-                    "These are ports that this integration binds to."
-                    "Most users can keep the defaults. Change only if the ports are "
-                    "already in use."
-                    "Note that this setting currently applies to all configured hubs."
-                    "The ports represents a base value, and the integration will try"
-                    "to find an open port within 32 ports of what you enter here."
-                    "The UDP port is optional; if you disable the proxy capabilty of"
-                    "the integration, no UDP port is used."
+                    "These are ports that this integration binds to. Most users can keep "
+                    "the defaults: UDP now defaults to 8102 so CALL_ME and NOTIFY_ME share a "
+                    "single listener compatible with Android and iOS. Change only if the port "
+                    "is already in use; a non-8102 UDP port may prevent iOS discovery. "
+                    "This setting currently applies to all configured hubs. The ports represent "
+                    "a base value, and the integration will try to find an open port within 32 "
+                    "ports of what you enter here. The UDP port is optional; if you disable the "
+                    "proxy capability of the integration, no UDP port is used."
                 )
             },
         )

--- a/custom_components/sofabaton_x1s/const.py
+++ b/custom_components/sofabaton_x1s/const.py
@@ -15,7 +15,7 @@ CONF_NOTIFY_BROADCASTS = "notify_broadcasts"
 # X1S devices report a higher NO field in their mDNS TXT records
 X1S_NO_THRESHOLD = 20221120
 
-DEFAULT_PROXY_UDP_PORT = 9102
+DEFAULT_PROXY_UDP_PORT = 8102
 DEFAULT_HUB_LISTEN_BASE = 8200
 
 PLATFORMS = ["select", "switch", "binary_sensor", "button", "sensor", "remote"]

--- a/custom_components/sofabaton_x1s/lib/cli.py
+++ b/custom_components/sofabaton_x1s/lib/cli.py
@@ -259,7 +259,12 @@ def main() -> None:
     ap = argparse.ArgumentParser(description="X1 proxy CLI")
     ap.add_argument("--hub", required=True, help="real hub IP (the real device)")
     ap.add_argument("--hub-udp", type=int, default=8102)
-    ap.add_argument("--proxy-udp", type=int, default=9102)
+    ap.add_argument(
+        "--proxy-udp",
+        type=int,
+        default=8102,
+        help="Single CALL_ME/NOTIFY_ME UDP port for all proxies (8102 recommended for iOS)",
+    )
     ap.add_argument("--listen-base", type=int, default=8200)
     ap.add_argument("--mdns-txt", action="append", help="add TXT record kv pair, e.g. NAME=YourHub (repeatable)")
     ap.add_argument("--disable-proxy", action="store_true", help="start with proxy disabled")

--- a/custom_components/sofabaton_x1s/lib/notify_demuxer.py
+++ b/custom_components/sofabaton_x1s/lib/notify_demuxer.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import logging
 import ipaddress
 import socket
+import struct
 import threading
 import time
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional
 
-from .protocol_const import SYNC0, SYNC1
+from .protocol_const import OP_CALL_ME, SYNC0, SYNC1
 
 log = logging.getLogger("x1proxy.notify")
 
@@ -45,6 +46,8 @@ class NotifyRegistration:
     real_hub_ip: str
     mdns_txt: Dict[str, str]
     call_me_port: int
+    call_me_cb: Callable[[str, int, str, int], None]
+    mac_bytes: bytes
 
 
 class NotifyDemuxer:
@@ -68,8 +71,16 @@ class NotifyDemuxer:
         real_hub_ip: str,
         mdns_txt: Dict[str, str],
         call_me_port: int,
+        call_me_cb: Callable[[str, int, str, int], None],
     ) -> None:
-        reg = NotifyRegistration(proxy_id, real_hub_ip, dict(mdns_txt), int(call_me_port))
+        reg = NotifyRegistration(
+            proxy_id,
+            real_hub_ip,
+            dict(mdns_txt),
+            int(call_me_port),
+            call_me_cb,
+            self._extract_mac_bytes(mdns_txt),
+        )
         with self._lock:
             self._registrations[proxy_id] = reg
             log.info(
@@ -139,7 +150,7 @@ class NotifyDemuxer:
         s.bind(("0.0.0.0", self.listen_port))
         s.settimeout(1.0)
         log.info(
-            "[DEMUX] listening for NOTIFY_ME on *:%d (SO_REUSEPORT=%s)",
+            "[DEMUX] listening for NOTIFY_ME/CALL_ME on *:%d (SO_REUSEPORT=%s)",
             self.listen_port,
             reuseport_enabled,
         )
@@ -157,58 +168,16 @@ class NotifyDemuxer:
             except OSError:
                 break
 
-            if pkt != NOTIFY_ME_PAYLOAD:
+            if pkt == NOTIFY_ME_PAYLOAD:
+                self._handle_notify_me(sock, pkt, src_ip, src_port)
                 continue
 
-            with self._lock:
-                registrations = list(self._registrations.values())
-
-            for reg in registrations:
-                key = (src_ip, src_port, reg.proxy_id)
-                now = time.monotonic()
-                last = self._last_reply.get(key, 0.0)
-                if now - last < 2.0:
-                    continue
-
-                reply = self._build_notify_reply(reg)
-                if reply is None:
-                    continue
-
-                self._last_reply[key] = now
-                dest_ip = _broadcast_ip(src_ip)
-                log.info(
-                    "[DEMUX] NOTIFY_ME from %s:%d -> proxy=%s CALL_ME=%d broadcast=%s",
-                    src_ip,
-                    src_port,
-                    reg.proxy_id,
-                    reg.call_me_port,
-                    dest_ip,
-                )
-                try:
-                    sock.sendto(reply, (dest_ip, BROADCAST_LISTEN_PORT))
-                except OSError:
-                    log.exception("[DEMUX] failed to send NOTIFY_ME reply for %s", reg.proxy_id)
+            if len(pkt) >= 16 and pkt[0] == SYNC0 and pkt[1] == SYNC1:
+                op = (pkt[2] << 8) | pkt[3]
+                if op == OP_CALL_ME:
+                    self._handle_call_me(pkt, src_ip, src_port)
 
     def _build_notify_reply(self, reg: NotifyRegistration) -> Optional[bytes]:
-        try:
-            mac_raw = (
-                reg.mdns_txt.get("MAC")
-                or reg.mdns_txt.get("mac")
-                or reg.mdns_txt.get("macaddress")
-            )
-            mac_bytes = (
-                bytes.fromhex(str(mac_raw).replace(":", "").replace("-", ""))
-                if mac_raw
-                else b""
-            )
-        except ValueError:
-            mac_bytes = b""
-
-        if len(mac_bytes) < 6:
-            mac_bytes = mac_bytes.ljust(6, b"\x00")
-        else:
-            mac_bytes = mac_bytes[:6]
-
         name = (
             reg.mdns_txt.get("NAME")
             or reg.mdns_txt.get("name")
@@ -223,7 +192,7 @@ class NotifyDemuxer:
 
         frame = (
             bytes([SYNC0, SYNC1, 0x1D])
-            + mac_bytes
+            + reg.mac_bytes
             + status_byte
             + version_block
             + name_bytes
@@ -233,17 +202,128 @@ class NotifyDemuxer:
         log.info(
             "[DEMUX][REPLY] proxy=%s mac=%s name=%s",
             reg.proxy_id,
-            mac_bytes.hex(":"),
+            reg.mac_bytes.hex(":"),
             name.decode("utf-8", "ignore"),
         )
         return frame
+
+    def _handle_notify_me(
+        self, sock: socket.socket, pkt: bytes, src_ip: str, src_port: int
+    ) -> None:
+        with self._lock:
+            registrations = list(self._registrations.values())
+
+        for reg in registrations:
+            key = (src_ip, src_port, reg.proxy_id)
+            now = time.monotonic()
+            last = self._last_reply.get(key, 0.0)
+            if now - last < 2.0:
+                continue
+
+            reply = self._build_notify_reply(reg)
+            if reply is None:
+                continue
+
+            self._last_reply[key] = now
+            dest_ip = _broadcast_ip(src_ip)
+            log.info(
+                "[DEMUX] NOTIFY_ME from %s:%d -> proxy=%s CALL_ME=%d broadcast=%s",
+                src_ip,
+                src_port,
+                reg.proxy_id,
+                reg.call_me_port,
+                dest_ip,
+            )
+            try:
+                sock.sendto(reply, (dest_ip, BROADCAST_LISTEN_PORT))
+            except OSError:
+                log.exception("[DEMUX] failed to send NOTIFY_ME reply for %s", reg.proxy_id)
+
+    def _handle_call_me(self, pkt: bytes, src_ip: str, src_port: int) -> None:
+        try:
+            app_ip = socket.inet_ntoa(pkt[10:14])
+            app_port = struct.unpack(">H", pkt[14:16])[0]
+        except Exception:
+            return
+
+        mac_hint = pkt[4:10]
+        with self._lock:
+            registrations = list(self._registrations.values())
+
+        reg = self._select_registration(mac_hint, registrations)
+        if reg is None:
+            log.warning(
+                "[DEMUX] CALL_ME from %s:%d ignored (no proxy match, mac=%s)",
+                src_ip,
+                src_port,
+                mac_hint.hex(":"),
+            )
+            return
+
+        log.info(
+            "[DEMUX] CALL_ME from %s:%d -> proxy=%s app tcp %s:%d",
+            src_ip,
+            src_port,
+            reg.proxy_id,
+            app_ip,
+            app_port,
+        )
+        try:
+            reg.call_me_cb(src_ip, src_port, app_ip, app_port)
+        except Exception:
+            log.exception("[DEMUX] proxy callback failed for %s", reg.proxy_id)
+
+    def _select_registration(
+        self, mac_hint: bytes, registrations: list[NotifyRegistration]
+    ) -> Optional[NotifyRegistration]:
+        if not registrations:
+            return None
+
+        has_hint = mac_hint and any(mac_hint)
+        if has_hint:
+            for reg in registrations:
+                if reg.mac_bytes == mac_hint:
+                    return reg
+
+        if len(registrations) == 1:
+            return registrations[0]
+
+        return None
+
+    def _extract_mac_bytes(self, mdns_txt: Dict[str, str]) -> bytes:
+        try:
+            mac_raw = (
+                mdns_txt.get("MAC")
+                or mdns_txt.get("mac")
+                or mdns_txt.get("macaddress")
+            )
+            mac_bytes = (
+                bytes.fromhex(str(mac_raw).replace(":", "").replace("-", ""))
+                if mac_raw
+                else b""
+            )
+        except ValueError:
+            mac_bytes = b""
+
+        if len(mac_bytes) < 6:
+            mac_bytes = mac_bytes.ljust(6, b"\x00")
+        else:
+            mac_bytes = mac_bytes[:6]
+
+        return mac_bytes
 
 
 _GLOBAL_DEMUXER: Optional[NotifyDemuxer] = None
 
 
-def get_notify_demuxer() -> NotifyDemuxer:
+def get_notify_demuxer(listen_port: Optional[int] = None) -> NotifyDemuxer:
     global _GLOBAL_DEMUXER
     if _GLOBAL_DEMUXER is None:
-        _GLOBAL_DEMUXER = NotifyDemuxer()
+        _GLOBAL_DEMUXER = NotifyDemuxer(listen_port or 8102)
+    elif listen_port is not None and listen_port != _GLOBAL_DEMUXER.listen_port:
+        log.warning(
+            "[DEMUX] existing listener on %d (ignoring requested %d)",
+            _GLOBAL_DEMUXER.listen_port,
+            listen_port,
+        )
     return _GLOBAL_DEMUXER

--- a/custom_components/sofabaton_x1s/lib/x1_proxy.py
+++ b/custom_components/sofabaton_x1s/lib/x1_proxy.py
@@ -165,7 +165,7 @@ class X1Proxy:
         self,
         real_hub_ip: str,
         real_hub_udp_port: int = 8102,
-        proxy_udp_port: int = 9102,
+        proxy_udp_port: int = 8102,
         hub_listen_base: int = 8200,
         mdns_instance: str = "X1-HUB-PROXY",
         mdns_host: Optional[str] = None,

--- a/custom_components/sofabaton_x1s/translations/en.json
+++ b/custom_components/sofabaton_x1s/translations/en.json
@@ -16,7 +16,7 @@
       },
       "ports": {
         "title": "Proxy ports",
-        "description": "These ports are used by the local proxy that emulates the hub. Most users can keep the defaults. Change them only if there is a conflict. Note that this setting currently applies to all configured hubs. The ports represents a base value, and the integration will try to find an open port within 32 ports of what you enter here.",
+        "description": "These ports are used by the local proxy that emulates the hub. UDP now defaults to 8102 so CALL_ME and NOTIFY_ME share a single listener that works for Android and iOS; changing it applies to all hubs and may prevent iOS discovery. The port values are bases, and the integration will try to find an open port within 32 ports of what you enter here.",
         "data": {
           "proxy_udp_port": "Proxy UDP base port",
           "hub_listen_base": "Hub TCP listen base",

--- a/tests/test_transport_bridge.py
+++ b/tests/test_transport_bridge.py
@@ -25,7 +25,7 @@ def test_connect_beacon_targets_broadcast_port(monkeypatch):
     monkeypatch.setattr(transport_bridge.socket, "socket", lambda *a, **k: FakeSocket())
 
     bridge = TransportBridge(
-        "192.168.2.10", 8102, 9102, 8200, proxy_id="proxy", mdns_instance="proxy", mdns_txt={}
+        "192.168.2.10", 8102, 8102, 8200, proxy_id="proxy", mdns_instance="proxy", mdns_txt={}
     )
     bridge._emit_connect_ready_beacon("192.168.2.15")
 
@@ -37,7 +37,7 @@ def test_connect_beacon_targets_broadcast_port(monkeypatch):
 
 def test_notify_listener_stops_when_connecting(monkeypatch):
     bridge = TransportBridge(
-        "192.168.2.10", 8102, 9102, 8200, proxy_id="proxy", mdns_instance="proxy", mdns_txt={}
+        "192.168.2.10", 8102, 8102, 8200, proxy_id="proxy", mdns_instance="proxy", mdns_txt={}
     )
     stopped = False
 
@@ -46,6 +46,15 @@ def test_notify_listener_stops_when_connecting(monkeypatch):
         stopped = True
 
     bridge._stop_notify_listener = fake_stop  # type: ignore[assignment]
+
+    class FakeDemuxer:
+        def register_proxy(self, *args, **kwargs):
+            pass
+
+        def unregister_proxy(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(transport_bridge, "get_notify_demuxer", lambda *a, **k: FakeDemuxer())
 
     class FailingSocket:
         def __init__(self, *_args, **_kwargs):


### PR DESCRIPTION
## Summary
- route both CALL_ME and NOTIFY_ME through a shared demuxer port with per-proxy callbacks and MAC-based routing
- register proxies with the demuxer even when broadcast relaying is disabled, keeping the single UDP listener configurable but defaulting to 8102
- update docs, UI copy, and CLI help to explain the unified port and warn that changing it may break iOS discovery

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925f7954a04832d8cd1f37d9b37adcc)