### PR TITLE
Update Zeroconf service info import

### DIFF
--- a/custom_components/sofabaton_x1s/config_flow.py
+++ b/custom_components/sofabaton_x1s/config_flow.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.core import callback
 
 from .const import (


### PR DESCRIPTION
## Summary
- replace deprecated ZeroconfServiceInfo import with recommended helper path for compatibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926366ef868832dbc2b454e0235e45c)