### PR TITLE
Add recorded keypress sensor

### DIFF
--- a/custom_components/sofabaton_x1s/lib/state_helpers.py
+++ b/custom_components/sofabaton_x1s/lib/state_helpers.py
@@ -16,7 +16,8 @@ class ActivityCache:
         self.devices: Dict[int, Dict[str, Any]] = {}
         self.buttons: Dict[int, set[int]] = {}
         self.commands: dict[int, dict[int, str]] = defaultdict(dict)
-        self.app_activations: Deque[dict[str, Any]] = deque(maxlen=50)
+        # Only track the most recent activation to avoid unbounded growth
+        self.app_activations: Deque[dict[str, Any]] = deque(maxlen=1)
 
     def set_hint(self, activity_id: Optional[int]) -> None:
         self.current_activity_hint = activity_id


### PR DESCRIPTION
## Summary
- add a dedicated recorded keypress sensor with relative recency state and context-focused attributes
- remove app activation data from the index sensor and surface only the latest keypress alongside a targeted remote.send_command example
- cap stored app activations to the most recent record to minimize memory use over long runtimes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928ed68ff80832db275488b4cba322f)