### PR TITLE
Add support for appending IP commands to existing devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ You should see:
 
 ## Creating virtual IP buttons
 
-The integration can provision a simple HTTP-backed virtual device/button on the hub using the `sofabaton_x1s.create_ip_button` service. Provide a device name, button label, HTTP method, full URL (including scheme/host), and optional headers mapping. The proxy mirrors the app’s observed frame layout (UTF-16LE padded names plus length-prefixed method/URL/header blobs) and returns the hub-assigned `device_id`/`button_id` when the transaction succeeds. Be sure the proxy can issue commands (the official app must not be connected) before invoking the service.
+The integration can provision a simple HTTP-backed virtual device/button on the hub using the `sofabaton_x1s.create_ip_button` service. Provide a device name, button label, HTTP method, full URL (including scheme/host), and optional headers mapping. You can also supply an existing `device_id` to append the new command as another button on that device instead of creating a fresh device. The proxy mirrors the app’s observed frame layout (UTF-16LE padded names plus length-prefixed method/URL/header blobs) and returns the hub-assigned `device_id`/`button_id` when the transaction succeeds. Be sure the proxy can issue commands (the official app must not be connected) before invoking the service.
 
 Verbose logging is emitted while the frame sequence is sent and while the hub acknowledges creation. Enabling the hex logging switch can help if the hub rejects a payload; the diagnostics will contain the exact frames sent and responses received.
 

--- a/custom_components/sofabaton_x1s/__init__.py
+++ b/custom_components/sofabaton_x1s/__init__.py
@@ -115,6 +115,7 @@ async def _async_handle_create_ip_button(call: ServiceCall):
     if hub is None:
         raise ValueError("Could not resolve Sofabaton hub from service call")
 
+    device_id = call.data.get("device_id")
     device_name = call.data["device_name"].strip()
     button_name = call.data["button_name"].strip()
     method = call.data.get("method", "GET").upper()
@@ -132,14 +133,24 @@ async def _async_handle_create_ip_button(call: ServiceCall):
     if not isinstance(headers, dict):
         raise ValueError("headers must be a mapping")
 
-    result = await hass.async_add_executor_job(
-        hub._proxy.create_ip_button,
-        device_name,
-        button_name,
-        method,
-        url,
-        headers,
-    )
+    if device_id is not None:
+        result = await hass.async_add_executor_job(
+            hub._proxy.add_ip_button_to_device,
+            int(device_id),
+            button_name,
+            method,
+            url,
+            headers,
+        )
+    else:
+        result = await hass.async_add_executor_job(
+            hub._proxy.create_ip_button,
+            device_name,
+            button_name,
+            method,
+            url,
+            headers,
+        )
 
     return result or {}
 

--- a/custom_components/sofabaton_x1s/lib/opcode_handlers.py
+++ b/custom_components/sofabaton_x1s/lib/opcode_handlers.py
@@ -32,10 +32,16 @@ from .protocol_const import (
     OP_KEYMAP_TBL_G,
     OP_CREATE_DEVICE_HEAD,
     OP_DEFINE_IP_CMD,
+    OP_DEFINE_IP_CMD_EXISTING,
     OP_PREPARE_SAVE,
     OP_FINALIZE_DEVICE,
     OP_DEVICE_SAVE_HEAD,
     OP_SAVE_COMMIT,
+    OP_REQ_IPCMD_SYNC,
+    OP_IPCMD_ROW_A,
+    OP_IPCMD_ROW_B,
+    OP_IPCMD_ROW_C,
+    OP_IPCMD_ROW_D,
     ACK_SUCCESS,
     OP_REQ_ACTIVATE,
     OP_REQ_BUTTONS,
@@ -215,6 +221,68 @@ class DefineIpCommandHandler(BaseFrameHandler):
             method or "?",
             url,
             ", ".join(f"{k}: {v}" for k, v in headers.items()) if headers else "{}",
+        )
+
+
+@register_handler(opcodes=(OP_DEFINE_IP_CMD_EXISTING,), directions=("A→H",))
+class DefineExistingIpCommandHandler(BaseFrameHandler):
+    """Capture metadata when the app adds an IP command to an existing device."""
+
+    def handle(self, frame: FrameContext) -> None:
+        proxy: X1Proxy = frame.proxy
+        payload = frame.payload
+        button_name = _decode_utf16le_segment(payload, start=16, length=64) or _decode_utf16le_segment(payload, start=16)
+        method, url, headers = _parse_ip_command_fields(payload[64:])
+        proxy.update_virtual_device(button_name=button_name, method=method, url=url, headers=headers)
+        log.info(
+            "[CREATE] existing dev button='%s' method=%s url='%s' headers=%s",
+            button_name,
+            method or "?",
+            url,
+            ", ".join(f"{k}: {v}" for k, v in headers.items()) if headers else "{}",
+        )
+
+
+@register_handler(
+    opcodes=(OP_IPCMD_ROW_A, OP_IPCMD_ROW_B, OP_IPCMD_ROW_C, OP_IPCMD_ROW_D),
+    directions=("H→A",),
+)
+class IpCommandSyncRowHandler(BaseFrameHandler):
+    """Decode IP command rows returned when syncing commands for an existing device."""
+
+    def handle(self, frame: FrameContext) -> None:
+        proxy: X1Proxy = frame.proxy
+        payload = frame.payload
+        proxy._burst.start("commands", now=time.monotonic())
+        if len(payload) > 6:
+            proxy._burst.start(f"commands:{payload[6]}", now=time.monotonic())
+
+        device_id = payload[6] if len(payload) > 6 else None
+        button_id = payload[7] if len(payload) > 7 else None
+        button_name = _decode_utf16le_segment(payload, start=16, length=64) or _decode_utf16le_segment(payload, start=16)
+        method, url, headers = _parse_ip_command_fields(payload[64:])
+
+        if device_id is None:
+            return
+
+        device_meta = proxy.state.devices.get(device_id & 0xFF, {})
+        proxy.state.record_virtual_device(
+            device_id,
+            name=device_meta.get("name") or f"Device {device_id}",
+            button_id=button_id,
+            method=method,
+            url=url,
+            headers=headers,
+            button_name=button_name,
+        )
+
+        log.info(
+            "[CREATE] sync dev=0x%04X btn=0x%02X name='%s' method=%s url='%s'",
+            device_id,
+            button_id or 0,
+            button_name,
+            method or "?",
+            url,
         )
 
 

--- a/custom_components/sofabaton_x1s/lib/protocol_const.py
+++ b/custom_components/sofabaton_x1s/lib/protocol_const.py
@@ -49,11 +49,19 @@ OP_REQ_ACTIVATE = 0x023F  # payload: [id_lo, key_code] (activity or device ID)
 OP_FIND_REMOTE = 0x0023  # payload: [0x01] to trigger remote buzzer
 OP_CREATE_DEVICE_HEAD = 0x07D5  # payload includes UTF-16LE device name
 OP_DEFINE_IP_CMD = 0x0ED3  # payload includes HTTP method/URL/headers
+OP_DEFINE_IP_CMD_EXISTING = 0x0EAE  # payload defines IP command for an existing device
 OP_PREPARE_SAVE = 0x4102  # payload triggers save transaction start
 OP_FINALIZE_DEVICE = 0x4677
 OP_DEVICE_SAVE_HEAD = 0x8D5D  # hub assigns device id
 OP_SAVE_COMMIT = 0x6501
 ACK_SUCCESS = 0x0301
+
+# IP command synchronization (existing devices)
+OP_REQ_IPCMD_SYNC = 0x0C02
+OP_IPCMD_ROW_A = 0x0DD3
+OP_IPCMD_ROW_B = 0x0DAC
+OP_IPCMD_ROW_C = 0x0D9B
+OP_IPCMD_ROW_D = 0x0DAE
 
 # H→A responses (from hub to app/client)
 OP_ACK_READY = 0x0160
@@ -111,10 +119,16 @@ OPNAMES: Dict[int, str] = {
     OP_FIND_REMOTE: "FIND_REMOTE",
     OP_CREATE_DEVICE_HEAD: "CREATE_DEVICE_HEAD",
     OP_DEFINE_IP_CMD: "DEFINE_IP_CMD",
+    OP_DEFINE_IP_CMD_EXISTING: "DEFINE_IP_CMD_EXISTING",
     OP_PREPARE_SAVE: "PREPARE_SAVE",
     OP_FINALIZE_DEVICE: "FINALIZE_DEVICE",
     OP_DEVICE_SAVE_HEAD: "DEVICE_SAVE_HEAD",
     OP_SAVE_COMMIT: "SAVE_COMMIT",
+    OP_REQ_IPCMD_SYNC: "REQ_IPCMD_SYNC",
+    OP_IPCMD_ROW_A: "IPCMD_ROW_A",
+    OP_IPCMD_ROW_B: "IPCMD_ROW_B",
+    OP_IPCMD_ROW_C: "IPCMD_ROW_C",
+    OP_IPCMD_ROW_D: "IPCMD_ROW_D",
     ACK_SUCCESS: "ACK_SUCCESS",
     OP_ACK_READY: "ACK_READY",
     OP_MARKER: "MARKER",
@@ -167,11 +181,17 @@ __all__ = [
     "OP_FIND_REMOTE",
     "OP_CREATE_DEVICE_HEAD",
     "OP_DEFINE_IP_CMD",
+    "OP_DEFINE_IP_CMD_EXISTING",
     "OP_PREPARE_SAVE",
     "OP_FINALIZE_DEVICE",
     "OP_DEVICE_SAVE_HEAD",
     "OP_SAVE_COMMIT",
     "ACK_SUCCESS",
+    "OP_REQ_IPCMD_SYNC",
+    "OP_IPCMD_ROW_A",
+    "OP_IPCMD_ROW_B",
+    "OP_IPCMD_ROW_C",
+    "OP_IPCMD_ROW_D",
     "OP_ACK_READY",
     "OP_MARKER",
     "OP_CATALOG_ROW_DEVICE",

--- a/custom_components/sofabaton_x1s/lib/x1_proxy.py
+++ b/custom_components/sofabaton_x1s/lib/x1_proxy.py
@@ -31,6 +31,7 @@ from .protocol_const import (
     OP_INFO_BANNER,
     OP_CREATE_DEVICE_HEAD,
     OP_DEFINE_IP_CMD,
+    OP_DEFINE_IP_CMD_EXISTING,
     OP_PREPARE_SAVE,
     OP_FINALIZE_DEVICE,
     OP_DEVICE_SAVE_HEAD,
@@ -51,6 +52,7 @@ from .protocol_const import (
     OP_REQ_ACTIVATE,
     OP_REQ_BUTTONS,
     OP_REQ_COMMANDS,
+    OP_REQ_IPCMD_SYNC,
     OP_REQ_DEVICES,
     OP_REQ_KEYLABELS,
     OP_REQ_VERSION,
@@ -379,6 +381,33 @@ class X1Proxy:
         ent_lo = ent_id & 0xFF
         self.enqueue_cmd(OP_REQ_COMMANDS, bytes([ent_lo, 0xFF]), expects_burst=True, burst_kind=f"commands:{ent_lo}")
         return True
+
+    def request_ip_commands_for_device(self, dev_id: int, *, wait: bool = False, timeout: float = 1.0) -> bool:
+        """Fetch IP command definitions for an existing device."""
+
+        if not self.can_issue_commands():
+            log.info("[CMD] request_ip_commands_for_device ignored: proxy client is connected"); return False
+
+        dev_lo = dev_id & 0xFF
+        event = threading.Event() if wait else None
+
+        if event:
+            def _done(_: str) -> None:
+                event.set()
+
+            self._burst.on_burst_end(f"commands:{dev_lo}", _done)
+
+        ok = self.enqueue_cmd(
+            OP_REQ_IPCMD_SYNC,
+            bytes([dev_lo, 0xFF, 0x14]),
+            expects_burst=True,
+            burst_kind=f"commands:{dev_lo}",
+        )
+
+        if event:
+            event.wait(timeout)
+
+        return ok
         
     def get_activities(self) -> tuple[dict[int, dict], bool]:
         if self.state.activities:
@@ -567,6 +596,42 @@ class X1Proxy:
             (OP_SAVE_COMMIT, b""),
         ]
 
+    def _encode_http_request(self, method: str, url: str, headers: dict[str, str]) -> bytes:
+        header_lines = "".join(f"{k}:{v}\r\n" for k, v in headers.items())
+        request = f"{method} {url} HTTP/1.1\r\n{header_lines}\r\n"
+        return request.encode("utf-8")
+
+    def _build_existing_device_frame(
+        self,
+        *,
+        device_id: int,
+        button_id: int,
+        button_name: str,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+    ) -> tuple[int, bytes]:
+        """Construct the opcode/payload needed to add an IP command to an existing device."""
+
+        header = bytes(
+            [
+                button_id & 0xFF,
+                0x00,
+                0x01,
+                0x01,
+                0x00,
+                0x01,
+                device_id & 0xFF,
+                button_id & 0xFF,
+                0x1C,
+            ]
+        ) + b"\x00" * 7
+
+        payload = bytearray(header)
+        payload.extend(self._utf16le_padded(button_name, length=64))
+        payload.extend(self._encode_http_request(method, url, headers))
+        return OP_DEFINE_IP_CMD_EXISTING, bytes(payload)
+
     def create_ip_button(
         self,
         *,
@@ -609,6 +674,50 @@ class X1Proxy:
                 result.get("method"),
                 result.get("url"),
             )
+        return result
+
+    def add_ip_button_to_device(
+        self,
+        *,
+        device_id: int,
+        button_name: str,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+    ) -> dict[str, Any] | None:
+        """Add an IP-backed command to an existing device."""
+
+        if not self.can_issue_commands():
+            log.info("[CREATE] add_ip_button_to_device ignored: proxy client is connected")
+            return None
+
+        self.request_ip_commands_for_device(device_id, wait=True)
+        existing = self.state.ip_buttons.get(device_id & 0xFF, {})
+        next_button_id = (max(existing.keys()) + 1) if existing else 1
+
+        device_name = self.state.devices.get(device_id & 0xFF, {}).get("name", f"Device {device_id}")
+
+        opcode, payload = self._build_existing_device_frame(
+            device_id=device_id,
+            button_id=next_button_id,
+            button_name=button_name,
+            method=method,
+            url=url,
+            headers=headers,
+        )
+
+        self.start_virtual_device(
+            device_name=device_name,
+            button_name=button_name,
+            method=method,
+            url=url,
+            headers=headers,
+        )
+
+        self._send_cmd_frame(opcode, payload)
+
+        result = self.wait_for_virtual_device(timeout=3.0)
+        self.request_ip_commands_for_device(device_id, wait=True)
         return result
 
     # ---------------------------------------------------------------------

--- a/custom_components/sofabaton_x1s/services.yaml
+++ b/custom_components/sofabaton_x1s/services.yaml
@@ -44,6 +44,15 @@ create_ip_button:
       required: true
       selector:
         text:
+    device_id:
+      name: Existing device id
+      description: Optional hub device id to append the button to instead of creating a new device.
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 255
+          mode: box
     button_name:
       name: Button name
       description: Label for the HTTP command.


### PR DESCRIPTION
## Summary
- add protocol constants and opcode handlers for existing-device IP command synchronization
- extend IP button creation service and proxy to append commands to existing devices
- document the new workflow and service field

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ce806adf4832dbeb7c159119accea)