### PR TITLE
Add support for appending IP commands to existing devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ You should see:
 
 ## Creating virtual IP buttons
 
-The integration can provision a simple HTTP-backed virtual device/button on the hub using the `sofabaton_x1s.create_ip_button` service. Provide a device name, button label, HTTP method, full URL (including scheme/host), and optional headers mapping. The proxy mirrors the app’s observed frame layout (UTF-16LE padded names plus length-prefixed method/URL/header blobs) and returns the hub-assigned `device_id`/`button_id` when the transaction succeeds. Be sure the proxy can issue commands (the official app must not be connected) before invoking the service.
+The integration can provision a simple HTTP-backed virtual device/button on the hub using the `sofabaton_x1s.create_ip_button` service. Provide a device name, button label, HTTP method, full URL (including scheme/host), and optional headers mapping. You can also supply an existing `device_id` to append the new command as another button on that device instead of creating a fresh device. The proxy mirrors the app’s observed frame layout (UTF-16LE padded names plus length-prefixed method/URL/header blobs) and returns the hub-assigned `device_id`/`button_id` when the transaction succeeds. Be sure the proxy can issue commands (the official app must not be connected) before invoking the service.
 
 Verbose logging is emitted while the frame sequence is sent and while the hub acknowledges creation. Enabling the hex logging switch can help if the hub rejects a payload; the diagnostics will contain the exact frames sent and responses received.
 

--- a/custom_components/sofabaton_x1s/__init__.py
+++ b/custom_components/sofabaton_x1s/__init__.py
@@ -115,6 +115,7 @@ async def _async_handle_create_ip_button(call: ServiceCall):
     if hub is None:
         raise ValueError("Could not resolve Sofabaton hub from service call")
 
+    device_id = call.data.get("device_id")
     device_name = call.data["device_name"].strip()
     button_name = call.data["button_name"].strip()
     method = call.data.get("method", "GET").upper()
@@ -132,14 +133,24 @@ async def _async_handle_create_ip_button(call: ServiceCall):
     if not isinstance(headers, dict):
         raise ValueError("headers must be a mapping")
 
-    result = await hass.async_add_executor_job(
-        hub._proxy.create_ip_button,
-        device_name,
-        button_name,
-        method,
-        url,
-        headers,
-    )
+    if device_id is not None:
+        result = await hass.async_add_executor_job(
+            hub._proxy.add_ip_button_to_device,
+            int(device_id),
+            button_name,
+            method,
+            url,
+            headers,
+        )
+    else:
+        result = await hass.async_add_executor_job(
+            hub._proxy.create_ip_button,
+            device_name,
+            button_name,
+            method,
+            url,
+            headers,
+        )
 
     return result or {}
 

--- a/custom_components/sofabaton_x1s/lib/protocol_const.py
+++ b/custom_components/sofabaton_x1s/lib/protocol_const.py
@@ -49,11 +49,19 @@ OP_REQ_ACTIVATE = 0x023F  # payload: [id_lo, key_code] (activity or device ID)
 OP_FIND_REMOTE = 0x0023  # payload: [0x01] to trigger remote buzzer
 OP_CREATE_DEVICE_HEAD = 0x07D5  # payload includes UTF-16LE device name
 OP_DEFINE_IP_CMD = 0x0ED3  # payload includes HTTP method/URL/headers
+OP_DEFINE_IP_CMD_EXISTING = 0x0EAE  # payload defines IP command for an existing device
 OP_PREPARE_SAVE = 0x4102  # payload triggers save transaction start
 OP_FINALIZE_DEVICE = 0x4677
 OP_DEVICE_SAVE_HEAD = 0x8D5D  # hub assigns device id
 OP_SAVE_COMMIT = 0x6501
 ACK_SUCCESS = 0x0301
+
+# IP command synchronization (existing devices)
+OP_REQ_IPCMD_SYNC = 0x0C02
+OP_IPCMD_ROW_A = 0x0DD3
+OP_IPCMD_ROW_B = 0x0DAC
+OP_IPCMD_ROW_C = 0x0D9B
+OP_IPCMD_ROW_D = 0x0DAE
 
 # H→A responses (from hub to app/client)
 OP_ACK_READY = 0x0160
@@ -111,10 +119,16 @@ OPNAMES: Dict[int, str] = {
     OP_FIND_REMOTE: "FIND_REMOTE",
     OP_CREATE_DEVICE_HEAD: "CREATE_DEVICE_HEAD",
     OP_DEFINE_IP_CMD: "DEFINE_IP_CMD",
+    OP_DEFINE_IP_CMD_EXISTING: "DEFINE_IP_CMD_EXISTING",
     OP_PREPARE_SAVE: "PREPARE_SAVE",
     OP_FINALIZE_DEVICE: "FINALIZE_DEVICE",
     OP_DEVICE_SAVE_HEAD: "DEVICE_SAVE_HEAD",
     OP_SAVE_COMMIT: "SAVE_COMMIT",
+    OP_REQ_IPCMD_SYNC: "REQ_IPCMD_SYNC",
+    OP_IPCMD_ROW_A: "IPCMD_ROW_A",
+    OP_IPCMD_ROW_B: "IPCMD_ROW_B",
+    OP_IPCMD_ROW_C: "IPCMD_ROW_C",
+    OP_IPCMD_ROW_D: "IPCMD_ROW_D",
     ACK_SUCCESS: "ACK_SUCCESS",
     OP_ACK_READY: "ACK_READY",
     OP_MARKER: "MARKER",
@@ -167,11 +181,17 @@ __all__ = [
     "OP_FIND_REMOTE",
     "OP_CREATE_DEVICE_HEAD",
     "OP_DEFINE_IP_CMD",
+    "OP_DEFINE_IP_CMD_EXISTING",
     "OP_PREPARE_SAVE",
     "OP_FINALIZE_DEVICE",
     "OP_DEVICE_SAVE_HEAD",
     "OP_SAVE_COMMIT",
     "ACK_SUCCESS",
+    "OP_REQ_IPCMD_SYNC",
+    "OP_IPCMD_ROW_A",
+    "OP_IPCMD_ROW_B",
+    "OP_IPCMD_ROW_C",
+    "OP_IPCMD_ROW_D",
     "OP_ACK_READY",
     "OP_MARKER",
     "OP_CATALOG_ROW_DEVICE",

--- a/custom_components/sofabaton_x1s/lib/x1_proxy.py
+++ b/custom_components/sofabaton_x1s/lib/x1_proxy.py
@@ -31,6 +31,7 @@ from .protocol_const import (
     OP_INFO_BANNER,
     OP_CREATE_DEVICE_HEAD,
     OP_DEFINE_IP_CMD,
+    OP_DEFINE_IP_CMD_EXISTING,
     OP_PREPARE_SAVE,
     OP_FINALIZE_DEVICE,
     OP_DEVICE_SAVE_HEAD,
@@ -51,6 +52,7 @@ from .protocol_const import (
     OP_REQ_ACTIVATE,
     OP_REQ_BUTTONS,
     OP_REQ_COMMANDS,
+    OP_REQ_IPCMD_SYNC,
     OP_REQ_DEVICES,
     OP_REQ_KEYLABELS,
     OP_REQ_VERSION,
@@ -379,6 +381,33 @@ class X1Proxy:
         ent_lo = ent_id & 0xFF
         self.enqueue_cmd(OP_REQ_COMMANDS, bytes([ent_lo, 0xFF]), expects_burst=True, burst_kind=f"commands:{ent_lo}")
         return True
+
+    def request_ip_commands_for_device(self, dev_id: int, *, wait: bool = False, timeout: float = 1.0) -> bool:
+        """Fetch IP command definitions for an existing device."""
+
+        if not self.can_issue_commands():
+            log.info("[CMD] request_ip_commands_for_device ignored: proxy client is connected"); return False
+
+        dev_lo = dev_id & 0xFF
+        event = threading.Event() if wait else None
+
+        if event:
+            def _done(_: str) -> None:
+                event.set()
+
+            self._burst.on_burst_end(f"commands:{dev_lo}", _done)
+
+        ok = self.enqueue_cmd(
+            OP_REQ_IPCMD_SYNC,
+            bytes([dev_lo, 0xFF, 0x14]),
+            expects_burst=True,
+            burst_kind=f"commands:{dev_lo}",
+        )
+
+        if event:
+            event.wait(timeout)
+
+        return ok
         
     def get_activities(self) -> tuple[dict[int, dict], bool]:
         if self.state.activities:
@@ -567,6 +596,42 @@ class X1Proxy:
             (OP_SAVE_COMMIT, b""),
         ]
 
+    def _encode_http_request(self, method: str, url: str, headers: dict[str, str]) -> bytes:
+        header_lines = "".join(f"{k}:{v}\r\n" for k, v in headers.items())
+        request = f"{method} {url} HTTP/1.1\r\n{header_lines}\r\n"
+        return request.encode("utf-8")
+
+    def _build_existing_device_frame(
+        self,
+        *,
+        device_id: int,
+        button_id: int,
+        button_name: str,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+    ) -> tuple[int, bytes]:
+        """Construct the opcode/payload needed to add an IP command to an existing device."""
+
+        header = bytes(
+            [
+                button_id & 0xFF,
+                0x00,
+                0x01,
+                0x01,
+                0x00,
+                0x01,
+                device_id & 0xFF,
+                button_id & 0xFF,
+                0x1C,
+            ]
+        ) + b"\x00" * 7
+
+        payload = bytearray(header)
+        payload.extend(self._utf16le_padded(button_name, length=64))
+        payload.extend(self._encode_http_request(method, url, headers))
+        return OP_DEFINE_IP_CMD_EXISTING, bytes(payload)
+
     def create_ip_button(
         self,
         *,
@@ -609,6 +674,50 @@ class X1Proxy:
                 result.get("method"),
                 result.get("url"),
             )
+        return result
+
+    def add_ip_button_to_device(
+        self,
+        *,
+        device_id: int,
+        button_name: str,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+    ) -> dict[str, Any] | None:
+        """Add an IP-backed command to an existing device."""
+
+        if not self.can_issue_commands():
+            log.info("[CREATE] add_ip_button_to_device ignored: proxy client is connected")
+            return None
+
+        self.request_ip_commands_for_device(device_id, wait=True)
+        existing = self.state.ip_buttons.get(device_id & 0xFF, {})
+        next_button_id = (max(existing.keys()) + 1) if existing else 1
+
+        device_name = self.state.devices.get(device_id & 0xFF, {}).get("name", f"Device {device_id}")
+
+        opcode, payload = self._build_existing_device_frame(
+            device_id=device_id,
+            button_id=next_button_id,
+            button_name=button_name,
+            method=method,
+            url=url,
+            headers=headers,
+        )
+
+        self.start_virtual_device(
+            device_name=device_name,
+            button_name=button_name,
+            method=method,
+            url=url,
+            headers=headers,
+        )
+
+        self._send_cmd_frame(opcode, payload)
+
+        result = self.wait_for_virtual_device(timeout=3.0)
+        self.request_ip_commands_for_device(device_id, wait=True)
         return result
 
     # ---------------------------------------------------------------------

--- a/custom_components/sofabaton_x1s/services.yaml
+++ b/custom_components/sofabaton_x1s/services.yaml
@@ -44,6 +44,15 @@ create_ip_button:
       required: true
       selector:
         text:
+    device_id:
+      name: Existing device id
+      description: Optional hub device id to append the button to instead of creating a new device.
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 255
+          mode: box
     button_name:
       name: Button name
       description: Label for the HTTP command.

--- a/tests/test_ip_commands.py
+++ b/tests/test_ip_commands.py
@@ -1,0 +1,112 @@
+"""Tests for IP command encoding/decoding helpers."""
+
+from __future__ import annotations
+
+from custom_components.sofabaton_x1s.lib.frame_handlers import FrameContext
+from custom_components.sofabaton_x1s.lib.opcode_handlers import IpCommandSyncRowHandler
+from custom_components.sofabaton_x1s.lib.protocol_const import (
+    OP_DEFINE_IP_CMD_EXISTING,
+    OP_IPCMD_ROW_A,
+    OP_IPCMD_ROW_B,
+    OP_IPCMD_ROW_C,
+    OP_IPCMD_ROW_D,
+)
+from custom_components.sofabaton_x1s.lib.x1_proxy import X1Proxy
+
+
+def _build_context(proxy: X1Proxy, raw_hex: str, opcode: int) -> FrameContext:
+    raw = bytes.fromhex(raw_hex)
+    payload = raw[4:-1]
+    return FrameContext(
+        proxy=proxy,
+        opcode=opcode,
+        direction="H→A",
+        payload=payload,
+        raw=raw,
+        name="test",
+    )
+
+
+def test_ip_command_sync_rows_decode_http_metadata() -> None:
+    proxy = X1Proxy(
+        "127.0.0.1", proxy_udp_port=0, proxy_enabled=False, diag_dump=False, diag_parse=False
+    )
+    handler = IpCommandSyncRowHandler()
+
+    frames = (
+        (
+            "a5 5a d3 0d 01 00 01 03 00 01 08 01 1c 00 00 00 00 00 00 00 54 00 00 00 6f 00 00 00 67 00 00 00 67 00 00 00 6c 00 00 00 65 00 00 00 20 00 00 00 4f 00 00 00 66 00 00 00 66 00 00 00 69 00 00 00 63 00 00 00 65 00 00 00 20 00 00 00 4c 00 00 c0 a8 02 4d 1f bb 00 7f 50 55 54 20 2f 61 70 69 2f 77 65 62 68 6f 6f 6b 2f 2d 50 31 45 54 48 55 6c 63 47 68 79 62 6c 64 64 71 48 51 6f 6c 41 70 53 54 20 48 54 54 50 2f 31 2e 31 0d 0a 48 6f 73 74 3a 31 39 32 2e 31 36 38 2e 32 2e 37 37 3a 38 31 32 33 0d 0a 43 6f 6e 74 65 6e 74 2d 54 79 70 65 3a 61 70 70 6c 69 63 61 74 69 6f 6e 2f 78 2d 77 77 77 2d 66 6f 72 6d 2d 75 72 6c 65 6e 63 6f 64 65 64 0d 0a 0d 0a 92 07",
+            OP_IPCMD_ROW_A,
+        ),
+        (
+            "a5 5a ac 0d 02 00 01 03 00 01 08 02 1c 00 00 00 00 00 00 00 74 00 65 00 73 00 74 00 62 00 75 00 74 00 74 00 6f 00 6e 00 32 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 c0 a8 02 bc 00 50 00 58 50 55 54 20 20 48 54 54 50 2f 31 2e 31 0d 0a 48 6f 73 74 3a 31 39 32 2e 31 36 38 2e 32 2e 31 38 38 3a 38 30 0d 0a 43 6f 6e 74 65 6e 74 2d 54 79 70 65 3a 61 70 70 6c 69 63 61 74 69 6f 6e 2f 78 2d 77 77 77 2d 66 6f 72 6d 2d 75 72 6c 65 6e 63 6f 64 65 64 0d 0a 0d 0a 0c d7",
+            OP_IPCMD_ROW_B,
+        ),
+        (
+            "a5 5a 9b 0d 03 00 01 03 00 01 08 03 1c 00 00 00 00 00 00 00 74 00 65 00 73 00 74 00 62 00 74 00 6e 00 33 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 bc 21 21 21 00 50 00 47 50 4f 53 54 20 20 48 54 54 50 2f 31 2e 31 0d 0a 48 6f 73 74 3a 31 38 38 2e 33 33 2e 33 33 2e 33 33 3a 38 30 0d 0a 43 6f 6e 74 65 6e 74 2d 54 79 70 65 3a 61 70 70 6c 69 63 61 74 69 6f 6e 2f 6a 73 6f 6e 0d 0a 0d 0a 2c 08",
+            OP_IPCMD_ROW_C,
+        ),
+        (
+            "a5 5a ae 0d 04 00 01 04 00 01 08 04 1c 00 00 00 00 00 00 00 74 00 73 00 74 00 34 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 6f 6f 6f 6f 00 50 00 5a 47 45 54 20 20 48 54 54 50 2f 31 2e 31 0d 0a 48 6f 73 74 3a 31 31 31 2e 31 31 31 2e 31 31 31 2e 31 31 31 3a 38 30 0d 0a 43 6f 6e 74 65 6e 74 2d 54 79 70 65 3a 61 70 70 6c 69 63 61 74 69 6f 6e 2f 78 2d 77 77 77 2d 66 6f 72 6d 2d 75 72 6c 65 6e 63 6f 64 65 64 0d 0a 0d 0a ca 5a",
+            OP_IPCMD_ROW_D,
+        ),
+    )
+
+    for raw_hex, opcode in frames:
+        handler.handle(_build_context(proxy, raw_hex, opcode))
+
+    buttons = proxy.state.ip_buttons[8]
+
+    assert buttons[1]["button_name"].startswith("Toggle Office")
+    assert buttons[1]["method"] == "PUT"
+    assert buttons[1]["url"] == "/api/webhook/-P1ETHUlcGhyblddqHQolApST"
+    assert buttons[1]["headers"] == {
+        "Host": "192.168.2.77:8123",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+
+    assert buttons[2]["button_name"] == "testbutton2"
+    assert buttons[2]["method"] == "PUT"
+    assert buttons[2]["url"] == ""
+    assert buttons[2]["headers"]["Host"] == "192.168.2.188:80"
+
+    assert buttons[3]["button_name"].startswith("testbtn3")
+    assert buttons[3]["method"] == "POST"
+    assert buttons[3]["url"] == ""
+    assert buttons[3]["headers"]["Content-Type"] == "application/json"
+
+    assert buttons[4]["button_name"].startswith("tst4")
+    assert buttons[4]["method"] == "GET"
+    assert buttons[4]["url"] == ""
+    assert buttons[4]["headers"] == {
+        "Host": "111.111.111.111:80",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+
+
+def test_build_existing_device_frame_encodes_http_request() -> None:
+    proxy = X1Proxy(
+        "127.0.0.1", proxy_udp_port=0, proxy_enabled=False, diag_dump=False, diag_parse=False
+    )
+
+    opcode, payload = proxy._build_existing_device_frame(
+        device_id=8,
+        button_id=4,
+        button_name="tst4",
+        method="GET",
+        url="http://example.local/api",
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert opcode == OP_DEFINE_IP_CMD_EXISTING
+    assert payload[0] == 4
+    assert payload[6] == 8
+    assert payload[7] == 4
+
+    name_blob = proxy._utf16le_padded("tst4", length=64)
+    assert payload[16 : 16 + 64] == name_blob
+
+    http_blob = proxy._encode_http_request(
+        "GET", "http://example.local/api", {"Content-Type": "application/json"}
+    )
+    assert payload.endswith(http_blob)


### PR DESCRIPTION
## Summary
- add protocol constants and opcode handlers for existing-device IP command synchronization
- extend IP button creation service and proxy to append commands to existing devices
- document the new workflow and service field
- add regression tests and parsing improvements for existing-device IP command frames

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ce806adf4832dbeb7c159119accea)