### PR TITLE
Add editable hub IP text entity

### DIFF
--- a/custom_components/sofabaton_x1s/const.py
+++ b/custom_components/sofabaton_x1s/const.py
@@ -17,7 +17,15 @@ X1S_NO_THRESHOLD = 20221120
 DEFAULT_PROXY_UDP_PORT = 8102
 DEFAULT_HUB_LISTEN_BASE = 8200
 
-PLATFORMS = ["select", "switch", "binary_sensor", "button", "sensor", "remote"]
+PLATFORMS = [
+    "select",
+    "switch",
+    "binary_sensor",
+    "button",
+    "sensor",
+    "remote",
+    "text",
+]
 
 
 def signal_activity(entry_id: str) -> str:
@@ -39,7 +47,7 @@ def signal_buttons(entry_id: str) -> str:
 def signal_devices(entry_id: str) -> str:
     return f"sofabaton_x1s_devices_{entry_id}"
 
-    
+
 def signal_commands(entry_id: str) -> str:
     return f"sofabaton_x1s_commands_{entry_id}"
 

--- a/custom_components/sofabaton_x1s/text.py
+++ b/custom_components/sofabaton_x1s/text.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import ipaddress
+import logging
+
+from homeassistant.components.text import TextEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CONF_HOST, CONF_MAC, CONF_NAME, DOMAIN
+from .hub import SofabatonHub, get_hub_model
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    hub: SofabatonHub = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([SofabatonHubIpText(hub, entry)])
+
+
+class SofabatonHubIpText(TextEntity):
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:ip"
+
+    def __init__(self, hub: SofabatonHub, entry: ConfigEntry) -> None:
+        self._hub = hub
+        self._entry = entry
+        self._attr_unique_id = f"{entry.data[CONF_MAC]}_ip_address"
+        self._attr_name = f"{entry.data[CONF_NAME]} hub IP address"
+
+    @property
+    def native_value(self) -> str | None:
+        return self._hub.host
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.data[CONF_MAC])},
+            name=self._entry.data[CONF_NAME],
+            model=get_hub_model(self._entry),
+        )
+
+    async def async_set_value(self, value: str) -> None:
+        new_host = value.strip()
+        try:
+            ip = ipaddress.ip_address(new_host)
+        except ValueError as err:
+            raise HomeAssistantError("Enter a valid IPv4 address for the hub") from err
+
+        if ip.version != 4:
+            raise HomeAssistantError("IPv4 addresses are required for the hub")
+
+        entry = self.hass.config_entries.async_get_entry(self._entry.entry_id)
+        if entry is None:
+            raise HomeAssistantError("Config entry missing for this hub")
+
+        if entry.data.get(CONF_HOST) == new_host:
+            return
+
+        _LOGGER.debug("[%s] Updating hub IP to %s via text entity", entry.entry_id, new_host)
+        self.hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_HOST: new_host}
+        )
+        await self.hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/sofabaton_x1s/translations/en.json
+++ b/custom_components/sofabaton_x1s/translations/en.json
@@ -31,8 +31,16 @@
   "options": {
     "step": {
       "init": {
+        "title": "Hub connection",
+        "description": "Update the IP address or TCP port for this hub. You can adjust proxy ports for all hubs on the next screen.",
+        "data": {
+          "host": "Hub IP address",
+          "port": "Hub TCP port"
+        }
+      },
+      "ports": {
         "title": "Proxy ports",
-        "description": "These ports are used by the local Sofabaton proxy. UDP (default 8102) lets the official app discover the virtual hub and is shared by all hubs, so changing it may break iOS discovery. TCP is the base port the physical hub connects to; each hub uses its own TCP port from a range of up to 32 ports starting at this base.",
+        "description": "These ports are used by the local Sofabaton proxy and apply to all hubs. UDP (default 8102) lets the official app discover the virtual hub, so changing it may break iOS discovery. TCP is the base port the physical hub connects to; each hub uses its own TCP port from a range of up to 32 ports starting at this base.",
         "data": {
           "hub_listen_base": "TCP listener port base (for the physical hub to connect)",
           "proxy_udp_port": "UDP Listener port (for the app to connect)"


### PR DESCRIPTION
## Summary
- add a per-hub text entity that exposes the current IP address for editing from the device page
- validate IPv4 input, persist the new host to the config entry, and reload the entry after updates
- register the text platform alongside existing entities so it appears under hub configuration

## Testing
- python -m compileall custom_components/sofabaton_x1s


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930a35cf118832d9fadb818de291e3b)