### PR TITLE
Support opcode family predicates and IP sync family

### DIFF
--- a/custom_components/sofabaton_x1s/lib/opcode_handlers.py
+++ b/custom_components/sofabaton_x1s/lib/opcode_handlers.py
@@ -39,6 +39,7 @@ from .protocol_const import (
     OP_DEVICE_SAVE_HEAD,
     OP_SAVE_COMMIT,
     OP_REQ_IPCMD_SYNC,
+    OP_IPCMD_ROWS,
     OP_IPCMD_ROW_A,
     OP_IPCMD_ROW_B,
     OP_IPCMD_ROW_C,
@@ -297,10 +298,7 @@ class DefineExistingIpCommandHandler(BaseFrameHandler):
         )
 
 
-@register_handler(
-    opcodes=(OP_IPCMD_ROW_A, OP_IPCMD_ROW_B, OP_IPCMD_ROW_C, OP_IPCMD_ROW_D),
-    directions=("H→A",),
-)
+@register_handler(opcodes=(OP_IPCMD_ROWS,), directions=("H→A",))
 class IpCommandSyncRowHandler(BaseFrameHandler):
     """Decode IP command rows returned when syncing commands for an existing device."""
 

--- a/custom_components/sofabaton_x1s/lib/x1_proxy.py
+++ b/custom_components/sofabaton_x1s/lib/x1_proxy.py
@@ -16,7 +16,6 @@ from .commands import DeviceCommandAssembler
 from .protocol_const import (
     BUTTONNAME_BY_CODE,
     ButtonName,
-    OPNAMES,
     OP_ACK_READY,
     OP_BANNER,
     OP_CALL_ME,
@@ -59,6 +58,7 @@ from .protocol_const import (
     OP_WIFI_FW,
     SYNC0,
     SYNC1,
+    opcode_name,
 )
 from .state_helpers import ActivityCache, BurstScheduler
 from .transport_bridge import TransportBridge
@@ -317,11 +317,11 @@ class X1Proxy:
             sender=self._send_cmd_frame,
         )
         if sent:
-            log.info("[CMD] queued %s (0x%04X) %dB", OPNAMES.get(opcode, f"OP_{opcode:04X}"), opcode, len(payload))
+            log.info("[CMD] queued %s (0x%04X) %dB", opcode_name(opcode), opcode, len(payload))
         else:
             log.info(
                 "[CMD] ignoring %s: proxy client is connected",
-                OPNAMES.get(opcode, f"OP_{opcode:04X}"),
+                opcode_name(opcode),
             )
         return sent
 
@@ -825,7 +825,7 @@ class X1Proxy:
         frame = self._build_frame(opcode, payload)
         log.info(
             "[SEND] hub %s (0x%04X) %dB",
-            OPNAMES.get(opcode, f"OP_{opcode:04X}"),
+            opcode_name(opcode),
             opcode,
             len(payload),
         )
@@ -875,7 +875,7 @@ class X1Proxy:
     # ---------------------------------------------------------------------
     def _log_frames(self, direction: str, frames: List[Tuple[int, bytes, bytes, int, int]]) -> None:
         for op, raw, payload, scid, ecid in frames:
-            name = OPNAMES.get(op, f"OP_{op:04X}")
+            name = opcode_name(op)
             note = f"#{scid}→#{ecid}" if scid != ecid else f"#{ecid}"
             log.info("[FRAME %s] %s %s (0x%04X) len=%d", note, direction, name, op, len(raw))
 

--- a/tests/test_frame_handlers.py
+++ b/tests/test_frame_handlers.py
@@ -1,0 +1,26 @@
+"""Tests for frame handler registry predicate support."""
+
+from __future__ import annotations
+
+from custom_components.sofabaton_x1s.lib.frame_handlers import (
+    BaseFrameHandler,
+    FrameHandlerRegistry,
+    register_handler,
+)
+
+
+def test_frame_handler_matches_family_predicate() -> None:
+    """Handlers can register family predicates alongside explicit opcodes."""
+
+    registry = FrameHandlerRegistry()
+
+    @register_handler(
+        opcodes=(lambda op: (op & 0xFF00) == 0x0D00,), directions=("H→A",), registry=registry
+    )
+    class FamilyHandler(BaseFrameHandler):
+        pass
+
+    handlers = list(registry.iter_for(0x0DAE, "H→A"))
+    assert handlers and isinstance(handlers[0], FamilyHandler)
+
+    assert not list(registry.iter_for(0x0C02, "H→A"))

--- a/tests/test_protocol_consts.py
+++ b/tests/test_protocol_consts.py
@@ -1,5 +1,6 @@
 """Unit tests for shared protocol constants."""
 
+import sys
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
@@ -9,6 +10,7 @@ CONST_PATH = ROOT / "custom_components" / "sofabaton_x1s" / "lib" / "protocol_co
 spec = spec_from_file_location("protocol_const", CONST_PATH)
 assert spec and spec.loader, "Unable to load protocol_const module"
 const = module_from_spec(spec)
+sys.modules[spec.name] = const
 spec.loader.exec_module(const)  # type: ignore[assignment]
 
 
@@ -26,3 +28,12 @@ def test_all_opcodes_have_names() -> None:
     }
 
     assert not missing, f"Missing opcode names: {sorted(missing)}"
+
+
+def test_opcode_families_provide_names() -> None:
+    """Verify opcode_name recognizes masked opcode families."""
+
+    assert const.opcode_name(const.OP_IPCMD_ROW_A) == const.OPNAMES[const.OP_IPCMD_ROW_A]
+    assert const.opcode_name(0x0DFF) == "IPCMD_ROW_FF"
+    assert const.opcode_name(0xAA3D).startswith("OP_3D_")
+    assert const.opcode_name(0xBB5D).startswith("OP_5D_")


### PR DESCRIPTION
## Summary
- allow frame handlers to register opcode family predicates alongside exact opcode values
- register IP command sync rows via a 0x0Dxx opcode family and expose opcode family metadata
- improve opcode logging helpers and tests, including family-aware naming

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930cccb95a0832d8b040de780c7e783)