### PR TITLE
Mark recorded keypress sensor as diagnostic

### DIFF
--- a/custom_components/sofabaton_x1s/sensor.py
+++ b/custom_components/sofabaton_x1s/sensor.py
@@ -205,6 +205,7 @@ class SofabatonRecordedKeypressSensor(SensorEntity):
     _attr_should_poll = False
     _attr_has_entity_name = True
     _attr_name = "Recorded keypress"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(self, hub: SofabatonHub, entry: ConfigEntry) -> None:
         self._hub = hub


### PR DESCRIPTION
## Summary
- mark the recorded keypress sensor as a diagnostic entity like the index sensor

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930d1095764832db50761edac7f0c42)