### PR TITLE
Handle REQ_COMMANDS responses from hub

### DIFF
--- a/custom_components/sofabaton_x1s/lib/opcode_handlers.py
+++ b/custom_components/sofabaton_x1s/lib/opcode_handlers.py
@@ -776,13 +776,29 @@ class KeymapHandler(BaseFrameHandler):
         return False
 
 
-@register_handler(opcodes=(OP_REQ_COMMANDS,), directions=("A→H",))
+@register_handler(opcodes=(OP_REQ_COMMANDS,), directions=("A→H", "H→A"))
 class RequestCommandsHandler(BaseFrameHandler):
-    """Log command list requests from the app."""
+    """Log command list requests/responses and parse inline payloads."""
 
     def handle(self, frame: FrameContext) -> None:
+        proxy: X1Proxy = frame.proxy
         payload = frame.payload
         dev_id = payload[0] if payload else 0
+
+        if frame.direction == "H→A":
+            commands = proxy.parse_device_commands(payload, dev_id)
+            if commands:
+                proxy.state.commands[dev_id & 0xFF] = commands
+                log.info(
+                    "[DEVCTL] H→A REQ_COMMANDS dev=0x%02X (%d) %s",
+                    dev_id,
+                    dev_id,
+                    " ".join(
+                        f"{cmd_id:2d} : {label}" for cmd_id, label in commands.items()
+                    ),
+                )
+            return
+
         log.info("[DEVCTL] A→H requesting commands dev=0x%02X (%d)", dev_id, dev_id)
 
 

--- a/tests/test_opcode_handlers.py
+++ b/tests/test_opcode_handlers.py
@@ -40,6 +40,7 @@ from custom_components.sofabaton_x1s.lib.frame_handlers import FrameContext
 from custom_components.sofabaton_x1s.lib.opcode_handlers import (
     DeviceButtonPayloadHandler,
     KeymapHandler,
+    RequestCommandsHandler,
     X1CatalogActivityHandler,
     X1CatalogDeviceHandler,
 )
@@ -52,6 +53,7 @@ from custom_components.sofabaton_x1s.lib.protocol_const import (
     OP_KEYMAP_TBL_E,
     OP_KEYMAP_TBL_F,
     OP_KEYMAP_TBL_G,
+    OP_REQ_COMMANDS,
     OP_X1_ACTIVITY,
     OP_X1_DEVICE,
 )
@@ -81,6 +83,20 @@ def _build_payload_context(proxy: X1Proxy, opcode: int, payload: bytes, name: st
         raw=raw,
         name=name,
     )
+
+
+def test_req_commands_response_payload_is_parsed() -> None:
+    proxy = X1Proxy(
+        "127.0.0.1", proxy_udp_port=0, proxy_enabled=False, diag_dump=False, diag_parse=False
+    )
+    handler = RequestCommandsHandler()
+
+    payload = bytes([0x01, 0x05, 0x03]) + b"\x00" * 6 + b"Test"
+    frame = _build_payload_context(proxy, OP_REQ_COMMANDS, payload, "REQ_COMMANDS")
+
+    handler.handle(frame)
+
+    assert proxy.state.commands.get(0x01) == {5: "Test"}
 
 
 def test_keymap_table_b_parses_buttons_response() -> None:


### PR DESCRIPTION
## Summary
- parse hub-directed REQ_COMMANDS frames and persist any inline command labels
- log parsed REQ_COMMANDS payloads and add regression coverage for command extraction

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930d81af60c832d92d127fe12ff4719)