### PR TITLE
Handle UTF-32 command labels from REQ_COMMANDS responses

### DIFF
--- a/custom_components/sofabaton_x1s/lib/commands.py
+++ b/custom_components/sofabaton_x1s/lib/commands.py
@@ -192,6 +192,22 @@ def _decode_label(label_bytes: bytes) -> str:
     if not trimmed:
         return ""
 
+    if len(trimmed) >= 4 and all(trimmed[i] == 0 for i in range(1, len(trimmed), 4)):
+        try:
+            utf32_label = trimmed.decode("utf-32-le").strip("\x00")
+            if utf32_label:
+                return utf32_label
+        except UnicodeDecodeError:
+            pass
+
+    without_nulls = bytes(b for b in trimmed if b)
+    try:
+        ascii_label = without_nulls.decode("ascii").strip()
+        if ascii_label:
+            return ascii_label
+    except UnicodeDecodeError:
+        pass
+
     # Modern hubs sometimes send labels as plain ASCII instead of UTF-16.
     if b"\x00" not in trimmed:
         try:


### PR DESCRIPTION
## Summary
- add coverage for the observed REQ_COMMANDS response that lists Toggle Office L and related commands
- improve command label decoding to handle UTF-32 style padding and null stripping so labels parse correctly

## Testing
- pytest tests/test_commands.py -k toggle_office


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693158d37204832da25d808b17392d34)