### PR TITLE
Add opcode family helpers and frame handler family matching

### DIFF
--- a/custom_components/sofabaton_x1s/lib/protocol_const.py
+++ b/custom_components/sofabaton_x1s/lib/protocol_const.py
@@ -168,6 +168,46 @@ OPNAMES: Dict[int, str] = {
 }
 
 
+def opcode_hi(opcode: int) -> int:
+    """Return the high byte of an opcode."""
+
+    return (opcode >> 8) & 0xFF
+
+
+def opcode_lo(opcode: int) -> int:
+    """Return the low byte of an opcode."""
+
+    return opcode & 0xFF
+
+
+def opcode_family(opcode: int) -> int:
+    """Return the low-byte "family" for list/table opcodes."""
+
+    return opcode_lo(opcode)
+
+
+# Known opcode families (low byte) grouped by semantic row/page type
+FAMILY_DEV_ROW = 0x0B  # device catalog rows (OP_CATALOG_ROW_DEVICE, OP_X1_DEVICE)
+FAMILY_ACT_ROW = 0x3B  # activity catalog rows (OP_CATALOG_ROW_ACTIVITY, OP_X1_ACTIVITY)
+FAMILY_LABELS = 0x13  # key label pages (OP_LABELS_A1/B1/A2/B2)
+FAMILY_KEYMAP = 0x3D  # keymap / continuation / devbtn-extra pages
+FAMILY_DEVBTNS = 0x5D  # device button pages (header, body, tail, variants)
+
+
+def group_known_opcodes_by_family() -> dict[int, list[str]]:
+    """Return a mapping of low-byte opcode families to names defined here."""
+
+    family_map: dict[int, list[str]] = {}
+    for name, value in globals().items():
+        if not name.startswith("OP_"):
+            continue
+        if not isinstance(value, int):
+            continue
+        low = opcode_lo(value)
+        family_map.setdefault(low, []).append(name)
+    return family_map
+
+
 __all__ = [
     "SYNC0",
     "SYNC1",
@@ -228,4 +268,12 @@ __all__ = [
     "OP_WIFI_FW",
     "OP_INFO_BANNER",
     "OPNAMES",
+    "opcode_hi",
+    "opcode_lo",
+    "opcode_family",
+    "FAMILY_DEV_ROW",
+    "FAMILY_ACT_ROW",
+    "FAMILY_LABELS",
+    "FAMILY_KEYMAP",
+    "FAMILY_DEVBTNS",
 ]

--- a/tests/test_protocol_consts.py
+++ b/tests/test_protocol_consts.py
@@ -26,3 +26,32 @@ def test_all_opcodes_have_names() -> None:
     }
 
     assert not missing, f"Missing opcode names: {sorted(missing)}"
+
+
+def test_opcode_byte_helpers() -> None:
+    """Ensure opcode helpers split into high and low bytes correctly."""
+
+    assert const.opcode_hi(0xD50B) == 0xD5
+    assert const.opcode_lo(0xD50B) == 0x0B
+    assert const.opcode_family(0xD50B) == const.opcode_lo(0xD50B)
+
+
+def test_family_constants_align_with_examples() -> None:
+    """Known low-byte families should match documented opcode examples."""
+
+    assert const.FAMILY_DEV_ROW == const.opcode_lo(const.OP_CATALOG_ROW_DEVICE)
+    assert const.FAMILY_DEV_ROW == const.opcode_lo(const.OP_X1_DEVICE)
+
+    assert const.FAMILY_ACT_ROW == const.opcode_lo(const.OP_CATALOG_ROW_ACTIVITY)
+    assert const.FAMILY_ACT_ROW == const.opcode_lo(const.OP_X1_ACTIVITY)
+
+    assert const.FAMILY_LABELS == const.opcode_lo(const.OP_LABELS_A1)
+    assert const.FAMILY_LABELS == const.opcode_lo(const.OP_LABELS_B1)
+    assert const.FAMILY_LABELS == const.opcode_lo(const.OP_LABELS_A2)
+    assert const.FAMILY_LABELS == const.opcode_lo(const.OP_LABELS_B2)
+
+    assert const.FAMILY_KEYMAP == const.opcode_lo(const.OP_KEYMAP_TBL_A)
+    assert const.FAMILY_KEYMAP == const.opcode_lo(const.OP_DEVBTN_EXTRA)
+
+    assert const.FAMILY_DEVBTNS == const.opcode_lo(const.OP_DEVBTN_HEADER)
+    assert const.FAMILY_DEVBTNS == const.opcode_lo(const.OP_DEVBTN_TAIL)


### PR DESCRIPTION
## Summary
- add opcode byte helper functions and family constants plus grouping utility
- allow frame handlers to match opcodes by low-byte family and expose decorator support
- introduce dev-button family helper with debug logging and extend protocol constant tests

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693161873730832d88ebf3acc99027cb)