### PR TITLE
Restrict keymap handler and add opcode family logging

### DIFF
--- a/custom_components/sofabaton_x1s/lib/commands.py
+++ b/custom_components/sofabaton_x1s/lib/commands.py
@@ -9,7 +9,6 @@ from typing import Dict, Iterable, Iterator, List, Tuple
 from .protocol_const import (
     FAMILY_DEVBTNS,
     opcode_family,
-    OP_DEVBTN_EXTRA,
     OP_DEVBTN_HEADER,
     OP_DEVBTN_MORE,
     OP_DEVBTN_PAGE,
@@ -19,6 +18,7 @@ from .protocol_const import (
     OP_DEVBTN_PAGE_ALT4,
     OP_DEVBTN_PAGE_ALT5,
     OP_DEVBTN_TAIL,
+    OP_KEYMAP_EXTRA,
 )
 
 
@@ -29,7 +29,6 @@ def _is_devbtn_family(opcode: int) -> bool:
 
 
 _KNOWN_DEVBTN_OPCODES: set[int] = {
-    OP_DEVBTN_EXTRA,
     OP_DEVBTN_HEADER,
     OP_DEVBTN_MORE,
     OP_DEVBTN_PAGE,
@@ -39,6 +38,7 @@ _KNOWN_DEVBTN_OPCODES: set[int] = {
     OP_DEVBTN_PAGE_ALT4,
     OP_DEVBTN_PAGE_ALT5,
     OP_DEVBTN_TAIL,
+    OP_KEYMAP_EXTRA,
 }
 
 
@@ -132,7 +132,7 @@ class DeviceCommandAssembler:
             if frame_no == 1 or burst.total_frames is None:
                 burst.total_frames = int.from_bytes(payload[4:6], "big") if len(payload) >= 6 else None
                 burst.frames.clear()
-        elif burst.total_frames is None and opcode in (OP_DEVBTN_TAIL, OP_DEVBTN_EXTRA, OP_DEVBTN_MORE):
+        elif burst.total_frames is None and opcode in (OP_DEVBTN_TAIL, OP_KEYMAP_EXTRA, OP_DEVBTN_MORE):
             burst.total_frames = frame_no
 
         data_start = self._data_offset(opcode)
@@ -146,7 +146,7 @@ class DeviceCommandAssembler:
             OP_DEVBTN_HEADER,
             OP_DEVBTN_PAGE,
             OP_DEVBTN_TAIL,
-            OP_DEVBTN_EXTRA,
+            OP_KEYMAP_EXTRA,
             OP_DEVBTN_MORE,
         ) and payload[:2] == b"\x01\x00":
             data_start = 7 if opcode == OP_DEVBTN_HEADER else 3
@@ -180,7 +180,7 @@ class DeviceCommandAssembler:
             and frames_are_contiguous
             and burst.total_frames > max_frame_no
             and burst.total_frames - max_frame_no <= 1
-            and opcode in (OP_DEVBTN_TAIL, OP_DEVBTN_EXTRA, OP_DEVBTN_MORE)
+            and opcode in (OP_DEVBTN_TAIL, OP_KEYMAP_EXTRA, OP_DEVBTN_MORE)
         ):
             ordered_payload = b"".join(burst.frames[i] for i in sorted(burst.frames))
             completed.append((dev_id, ordered_payload))

--- a/custom_components/sofabaton_x1s/lib/opcode_handlers.py
+++ b/custom_components/sofabaton_x1s/lib/opcode_handlers.py
@@ -10,10 +10,10 @@ from .frame_handlers import BaseFrameHandler, FrameContext, register_handler
 from .protocol_const import (
     BUTTONNAME_BY_CODE,
     ButtonName,
+    FAMILY_KEYMAP,
     OP_ACK_READY,
     OP_CATALOG_ROW_ACTIVITY,
     OP_CATALOG_ROW_DEVICE,
-    OP_DEVBTN_EXTRA,
     OP_DEVBTN_HEADER,
     OP_DEVBTN_MORE,
     OP_DEVBTN_PAGE,
@@ -50,6 +50,7 @@ from .protocol_const import (
     OP_REQ_ACTIVITIES,
     OP_X1_ACTIVITY,
     OP_X1_DEVICE,
+    OP_KEYMAP_EXTRA,
 )
 from .x1_proxy import log
 
@@ -638,7 +639,10 @@ class X1CatalogActivityHandler(BaseFrameHandler):
             log.info("[ACT] name='%s' state=%s", activity_label, state)
 
 
-@register_handler(directions=("H→A",))
+@register_handler(
+    opcode_families_low=(FAMILY_KEYMAP,),
+    directions=("H→A",),
+)
 class KeymapHandler(BaseFrameHandler):
     """Accumulate keymap table pages for activities."""
 
@@ -665,7 +669,7 @@ class KeymapHandler(BaseFrameHandler):
             OP_KEYMAP_TBL_E,
             OP_KEYMAP_TBL_F,
             OP_KEYMAP_TBL_G,
-            OP_DEVBTN_EXTRA,
+            OP_KEYMAP_EXTRA,
         }
 
         burst_act_lo = self._burst_activity(proxy)
@@ -673,7 +677,7 @@ class KeymapHandler(BaseFrameHandler):
             OP_KEYMAP_CONT: 16,
             OP_KEYMAP_TBL_D: 16,
             OP_KEYMAP_TBL_F: 16,
-            OP_DEVBTN_EXTRA: 16,
+            OP_KEYMAP_EXTRA: 16,
         }
         activity_idx = activity_offsets.get(frame.opcode, 11)
         activity_id_decimal = burst_act_lo

--- a/custom_components/sofabaton_x1s/lib/protocol_const.py
+++ b/custom_components/sofabaton_x1s/lib/protocol_const.py
@@ -72,7 +72,7 @@ OP_CATALOG_ROW_ACTIVITY = 0xD53B  # Row from list of activities
 OP_DEVBTN_HEADER = 0xD95D  # H→A: header page
 OP_DEVBTN_PAGE = 0xD55D  # H→A: repeated pages with 2-3 entries each
 OP_DEVBTN_TAIL = 0x495D  # H→A: tail/terminator
-OP_DEVBTN_EXTRA = 0x303D  # H→A: small follow-up page sometimes present
+OP_KEYMAP_EXTRA = 0x303D  # H→A: small follow-up page sometimes present (keymap family)
 OP_DEVBTN_MORE = 0x8F5D  # H→A: small follow-up page sometimes present
 OP_DEVBTN_PAGE_ALT1 = 0xF75D  # H→A: variant page layout with earlier payload offset
 OP_DEVBTN_PAGE_ALT2 = 0xA35D  # H→A: variant page layout with earlier payload offset
@@ -145,7 +145,7 @@ OPNAMES: Dict[int, str] = {
     OP_DEVBTN_HEADER: "DEVCTL_HEADER",
     OP_DEVBTN_PAGE: "DEVCTL_PAGE",
     OP_DEVBTN_TAIL: "DEVCTL_LASTPAGE_TYPE1",
-    OP_DEVBTN_EXTRA: "DEVCTL_LASTPAGE_TYPE2",
+    OP_KEYMAP_EXTRA: "DEVCTL_LASTPAGE_TYPE2",
     OP_DEVBTN_MORE: "DEVCTL_LASTPAGE_TYPE3",
     OP_DEVBTN_PAGE_ALT1: "DEVCTL_PAGE_ALT1",
     OP_DEVBTN_PAGE_ALT2: "DEVCTL_PAGE_ALT2",
@@ -239,7 +239,7 @@ __all__ = [
     "OP_DEVBTN_HEADER",
     "OP_DEVBTN_PAGE",
     "OP_DEVBTN_TAIL",
-    "OP_DEVBTN_EXTRA",
+    "OP_KEYMAP_EXTRA",
     "OP_DEVBTN_MORE",
     "OP_DEVBTN_PAGE_ALT1",
     "OP_DEVBTN_PAGE_ALT2",

--- a/custom_components/sofabaton_x1s/lib/x1_proxy.py
+++ b/custom_components/sofabaton_x1s/lib/x1_proxy.py
@@ -17,12 +17,14 @@ from .protocol_const import (
     BUTTONNAME_BY_CODE,
     ButtonName,
     OPNAMES,
+    opcode_family,
+    opcode_hi,
+    opcode_lo,
     OP_ACK_READY,
     OP_BANNER,
     OP_CALL_ME,
     OP_CATALOG_ROW_ACTIVITY,
     OP_CATALOG_ROW_DEVICE,
-    OP_DEVBTN_EXTRA,
     OP_DEVBTN_HEADER,
     OP_DEVBTN_MORE,
     OP_DEVBTN_PAGE,
@@ -42,6 +44,7 @@ from .protocol_const import (
     OP_KEYMAP_TBL_C,
     OP_KEYMAP_TBL_D,
     OP_KEYMAP_TBL_E,
+    OP_KEYMAP_EXTRA,
     OP_LABELS_A1,
     OP_LABELS_A2,
     OP_LABELS_B1,
@@ -876,8 +879,19 @@ class X1Proxy:
     def _log_frames(self, direction: str, frames: List[Tuple[int, bytes, bytes, int, int]]) -> None:
         for op, raw, payload, scid, ecid in frames:
             name = OPNAMES.get(op, f"OP_{op:04X}")
+            hi = opcode_hi(op)
+            fam = opcode_family(op)
             note = f"#{scid}→#{ecid}" if scid != ecid else f"#{ecid}"
             log.info("[FRAME %s] %s %s (0x%04X) len=%d", note, direction, name, op, len(raw))
+
+            if op not in OPNAMES:
+                log.debug(
+                    "[FRAME %s] unknown opcode 0x%04X hi=0x%02X family(lo)=0x%02X",
+                    direction,
+                    op,
+                    hi,
+                    fam,
+                )
 
             context = FrameContext(
                 proxy=self,

--- a/tests/test_opcode_handlers.py
+++ b/tests/test_opcode_handlers.py
@@ -44,7 +44,7 @@ from custom_components.sofabaton_x1s.lib.opcode_handlers import (
 )
 from custom_components.sofabaton_x1s.lib.protocol_const import (
     ButtonName,
-    OP_DEVBTN_EXTRA,
+    OP_KEYMAP_EXTRA,
     OP_KEYMAP_CONT,
     OP_KEYMAP_TBL_B,
     OP_KEYMAP_TBL_D,
@@ -239,8 +239,8 @@ def test_devbtn_extra_contains_pause_and_red() -> None:
     frame = _build_context(
         proxy,
         "a5 5a 30 3d 01 00 02 14 00 00 00 00 00 00 00 00 65 bc 02 00 00 00 00 00 a6 0e 02 00 00 00 00 00 92 0f 65 be 02 00 00 00 00 00 00 20 00 00 00 00 00 00 00 00 42",
-        OP_DEVBTN_EXTRA,
-        "DEVBTN_EXTRA",
+        OP_KEYMAP_EXTRA,
+        "KEYMAP_EXTRA",
     )
 
     handler.handle(frame)

--- a/tests/test_protocol_consts.py
+++ b/tests/test_protocol_consts.py
@@ -51,7 +51,7 @@ def test_family_constants_align_with_examples() -> None:
     assert const.FAMILY_LABELS == const.opcode_lo(const.OP_LABELS_B2)
 
     assert const.FAMILY_KEYMAP == const.opcode_lo(const.OP_KEYMAP_TBL_A)
-    assert const.FAMILY_KEYMAP == const.opcode_lo(const.OP_DEVBTN_EXTRA)
+    assert const.FAMILY_KEYMAP == const.opcode_lo(const.OP_KEYMAP_EXTRA)
 
     assert const.FAMILY_DEVBTNS == const.opcode_lo(const.OP_DEVBTN_HEADER)
     assert const.FAMILY_DEVBTNS == const.opcode_lo(const.OP_DEVBTN_TAIL)


### PR DESCRIPTION
## Summary
- rename OP_DEVBTN_EXTRA to OP_KEYMAP_EXTRA and update references
- scope KeymapHandler registration to the keymap opcode family
- add debug logging to show opcode high byte and family for unknown opcodes

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69316ceda8b0832dad2d98832035896a)