### PR TITLE
Add targeted single command support

### DIFF
--- a/custom_components/sofabaton_x1s/lib/protocol_const.py
+++ b/custom_components/sofabaton_x1s/lib/protocol_const.py
@@ -71,6 +71,7 @@ OP_CATALOG_ROW_DEVICE = 0xD50B  # Row from list of devices
 OP_CATALOG_ROW_ACTIVITY = 0xD53B  # Row from list of activities
 OP_DEVBTN_HEADER = 0xD95D  # H→A: header page
 OP_DEVBTN_PAGE = 0xD55D  # H→A: repeated pages with 2-3 entries each
+OP_DEVBTN_SINGLE = 0x4D5D  # H→A: single-command metadata page (response to targeted REQ_COMMANDS)
 OP_DEVBTN_TAIL = 0x495D  # H→A: tail/terminator
 OP_KEYMAP_EXTRA = 0x303D  # H→A: small follow-up page sometimes present (keymap family)
 OP_DEVBTN_MORE = 0x8F5D  # H→A: small follow-up page sometimes present
@@ -144,6 +145,7 @@ OPNAMES: Dict[int, str] = {
     OP_KEYMAP_CONT: "KEYMAP_CONT",
     OP_DEVBTN_HEADER: "DEVCTL_HEADER",
     OP_DEVBTN_PAGE: "DEVCTL_PAGE",
+    OP_DEVBTN_SINGLE: "DEVCTL_SINGLE_CMD",
     OP_DEVBTN_TAIL: "DEVCTL_LASTPAGE_TYPE1",
     OP_KEYMAP_EXTRA: "DEVCTL_LASTPAGE_TYPE2",
     OP_DEVBTN_MORE: "DEVCTL_LASTPAGE_TYPE3",
@@ -238,6 +240,7 @@ __all__ = [
     "OP_CATALOG_ROW_ACTIVITY",
     "OP_DEVBTN_HEADER",
     "OP_DEVBTN_PAGE",
+    "OP_DEVBTN_SINGLE",
     "OP_DEVBTN_TAIL",
     "OP_KEYMAP_EXTRA",
     "OP_DEVBTN_MORE",

--- a/tests/test_protocol_consts.py
+++ b/tests/test_protocol_consts.py
@@ -55,3 +55,4 @@ def test_family_constants_align_with_examples() -> None:
 
     assert const.FAMILY_DEVBTNS == const.opcode_lo(const.OP_DEVBTN_HEADER)
     assert const.FAMILY_DEVBTNS == const.opcode_lo(const.OP_DEVBTN_TAIL)
+    assert const.FAMILY_DEVBTNS == const.opcode_lo(const.OP_DEVBTN_SINGLE)

--- a/tests/test_x1_proxy.py
+++ b/tests/test_x1_proxy.py
@@ -1,5 +1,6 @@
 """Tests for x1_proxy helpers."""
 
+from custom_components.sofabaton_x1s.lib.protocol_const import OP_REQ_COMMANDS
 from custom_components.sofabaton_x1s.lib.state_helpers import ActivityCache
 from custom_components.sofabaton_x1s.lib.x1_proxy import X1Proxy
 
@@ -16,24 +17,74 @@ def test_ensure_commands_for_activity_groups_by_device(monkeypatch) -> None:
     }
     proxy.state = cache
 
-    calls: list[tuple[int, bool]] = []
+    calls: list[tuple[int, int, bool]] = []
 
-    def fake_get_commands(ent_id: int, fetch_if_missing: bool = True):
-        calls.append((ent_id, fetch_if_missing))
+    def fake_get_single(ent_id: int, command_id: int, fetch_if_missing: bool = True):
+        calls.append((ent_id, command_id, fetch_if_missing))
         mappings = {
-            0x01: {0x1111: "one", 0x2222: "two"},
-            0x02: {0x3333: "three"},
+            (0x01, 0x1111): ({0x1111: "one"}, True),
+            (0x01, 0x2222): ({0x2222: "two"}, False),
+            (0x02, 0x3333): ({0x3333: "three"}, True),
         }
-        return (dict(mappings.get(ent_id & 0xFF, {})), True)
+        return mappings.get((ent_id, command_id), ({}, False))
 
-    monkeypatch.setattr(proxy, "get_commands_for_entity", fake_get_commands)
+    monkeypatch.setattr(proxy, "get_single_command_for_entity", fake_get_single)
 
     commands_by_device, ready = proxy.ensure_commands_for_activity(act)
 
-    assert ready is True
-    assert calls == [(0x01, True), (0x02, True)]
+    assert ready is False
+    assert set(calls) == {
+        (0x01, 0x1111, True),
+        (0x01, 0x2222, True),
+        (0x02, 0x3333, True),
+    }
     assert commands_by_device == {
         0x01: {0x1111: "one", 0x2222: "two"},
         0x02: {0x3333: "three"},
     }
+
+
+def test_get_single_command_for_entity_uses_cache(monkeypatch) -> None:
+    proxy = X1Proxy("127.0.0.1", proxy_enabled=False, diag_dump=False, diag_parse=False)
+    proxy.state.commands[0x02] = {0x1234: "Cmd"}
+
+    enqueue_called = False
+
+    def fake_enqueue(*args, **kwargs):
+        nonlocal enqueue_called
+        enqueue_called = True
+
+    monkeypatch.setattr(proxy, "enqueue_cmd", fake_enqueue)
+
+    commands, ready = proxy.get_single_command_for_entity(0x02, 0x1234)
+
+    assert ready is True
+    assert commands == {0x1234: "Cmd"}
+    assert enqueue_called is False
+
+
+def test_get_single_command_for_entity_enqueues_targeted_request(monkeypatch) -> None:
+    proxy = X1Proxy("127.0.0.1", proxy_enabled=False, diag_dump=False, diag_parse=False)
+
+    enqueued: list[tuple[int, bytes, bool, str | None]] = []
+
+    def fake_enqueue(opcode, payload, expects_burst=False, burst_kind=None):
+        enqueued.append((opcode, payload, expects_burst, burst_kind))
+
+    monkeypatch.setattr(proxy, "enqueue_cmd", fake_enqueue)
+    monkeypatch.setattr(proxy, "can_issue_commands", lambda: True)
+
+    command_id = 0x0A0B0C0D
+    commands, ready = proxy.get_single_command_for_entity(0x12, command_id)
+
+    assert commands == {}
+    assert ready is False
+    assert enqueued == [
+        (
+            OP_REQ_COMMANDS,
+            bytes([0x12]) + command_id.to_bytes(4, "little"),
+            True,
+            "commands:18:168496141",
+        )
+    ]
 


### PR DESCRIPTION
## Summary
- add protocol constant and opcode name for single-command device button responses
- teach command assembly and proxy logic to request and parse targeted command metadata
- extend tests for new opcode handling and per-command fetching

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69321c9a05c8832d93acd9523e380c04)