### PR TITLE
Request full command lists for high-byte favorite commands

### DIFF
--- a/custom_components/sofabaton_x1s/lib/opcode_handlers.py
+++ b/custom_components/sofabaton_x1s/lib/opcode_handlers.py
@@ -734,6 +734,23 @@ class KeymapHandler(BaseFrameHandler):
         for i in range(len(payload) - 1):
             if payload[i] == act_lo and payload[i + 1] in BUTTONNAME_BY_CODE:
                 return True
+
+        # Some payloads (favorites) only contain button IDs that are not part of
+        # the known mapping table. These still follow a recognizable layout of
+        # 18-byte records with zeroed padding between the device and command
+        # identifiers, so look for that structure as a fallback.
+        RECORD_SIZE = 18
+        for i in range(len(payload) - RECORD_SIZE + 1):
+            if payload[i] != act_lo:
+                continue
+
+            looks_like_favorite_record = (
+                payload[i + 3 : i + 7] == b"\x00" * 4
+                and payload[i + 12 : i + 18] == b"\x00" * 6
+            )
+
+            if looks_like_favorite_record:
+                return True
         return False
 
 

--- a/custom_components/sofabaton_x1s/lib/x1_proxy.py
+++ b/custom_components/sofabaton_x1s/lib/x1_proxy.py
@@ -499,17 +499,24 @@ class X1Proxy:
         if device_cmds is not None and command_id in device_cmds:
             return ({command_id: device_cmds[command_id]}, True)
 
-        if fetch_if_missing and self.can_issue_commands():
-            payload = bytes([ent_lo, int(command_id) & 0xFF])
+        if not fetch_if_missing or not self.can_issue_commands():
+            return ({}, False)
 
+        if command_id > 0xFF:
             if ent_lo not in self._pending_command_requests:
-                self._pending_command_requests.add(ent_lo)
-                self.enqueue_cmd(
-                    OP_REQ_COMMANDS,
-                    payload,
-                    expects_burst=True,
-                    burst_kind=f"commands:{ent_lo}:{command_id}",
-                )
+                self.request_commands_for_entity(ent_lo)
+            return ({}, False)
+
+        payload = bytes([ent_lo, int(command_id) & 0xFF])
+
+        if ent_lo not in self._pending_command_requests:
+            self._pending_command_requests.add(ent_lo)
+            self.enqueue_cmd(
+                OP_REQ_COMMANDS,
+                payload,
+                expects_burst=True,
+                burst_kind=f"commands:{ent_lo}:{command_id}",
+            )
 
         return ({}, False)
 

--- a/tests/test_x1_proxy.py
+++ b/tests/test_x1_proxy.py
@@ -126,7 +126,7 @@ def test_get_single_command_for_entity_enqueues_targeted_request(monkeypatch) ->
     monkeypatch.setattr(proxy, "enqueue_cmd", fake_enqueue)
     monkeypatch.setattr(proxy, "can_issue_commands", lambda: True)
 
-    command_id = 0x0A0B0C0D
+    command_id = 0x0D
     commands, ready = proxy.get_single_command_for_entity(0x12, command_id)
 
     assert commands == {}
@@ -136,7 +136,33 @@ def test_get_single_command_for_entity_enqueues_targeted_request(monkeypatch) ->
             OP_REQ_COMMANDS,
             bytes([0x12, command_id & 0xFF]),
             True,
-            "commands:18:168496141",
+            "commands:18:13",
+        )
+    ]
+
+
+def test_get_single_command_for_entity_requests_full_list_for_high_byte(monkeypatch) -> None:
+    proxy = X1Proxy("127.0.0.1", proxy_enabled=False, diag_dump=False, diag_parse=False)
+
+    enqueued: list[tuple[int, bytes, bool, str | None]] = []
+
+    def fake_enqueue(opcode, payload, expects_burst=False, burst_kind=None):
+        enqueued.append((opcode, payload, expects_burst, burst_kind))
+
+    monkeypatch.setattr(proxy, "enqueue_cmd", fake_enqueue)
+    monkeypatch.setattr(proxy, "can_issue_commands", lambda: True)
+
+    command_id = 0x0103
+    commands, ready = proxy.get_single_command_for_entity(0x12, command_id)
+
+    assert commands == {}
+    assert ready is False
+    assert enqueued == [
+        (
+            OP_REQ_COMMANDS,
+            bytes([0x12, 0xFF]),
+            True,
+            "commands:18",
         )
     ]
 


### PR DESCRIPTION
## Summary
- fetch full device command listings when favorite command IDs are larger than one byte
- keep targeted command requests for byte-sized IDs and add coverage for both paths

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932376d512c832db8e91ab22dc1288d)