### PR TITLE
Reset caches before fetching commands

### DIFF
--- a/custom_components/sofabaton_x1s/lib/x1_proxy.py
+++ b/custom_components/sofabaton_x1s/lib/x1_proxy.py
@@ -577,6 +577,28 @@ class X1Proxy:
 
         return (commands_by_device, all_ready)
 
+    def clear_entity_cache(
+        self,
+        ent_id: int,
+        *,
+        clear_buttons: bool = False,
+        clear_favorites: bool = False,
+    ) -> None:
+        """Remove cached data for a given entity."""
+
+        ent_lo = ent_id & 0xFF
+
+        self.state.commands.pop(ent_lo, None)
+        self._pending_command_requests.pop(ent_lo, None)
+
+        if clear_buttons:
+            self.state.buttons.pop(ent_lo, None)
+            self._pending_button_requests.discard(ent_lo)
+
+        if clear_favorites:
+            self.state.activity_command_refs.pop(ent_lo, None)
+            self.state.activity_favorite_slots.pop(ent_lo, None)
+
     def get_app_activations(self) -> list[dict[str, Any]]:
         return self.state.get_app_activations()
     


### PR DESCRIPTION
## Summary
- reset cached commands, buttons, and favorites before servicing fetch_device_commands
- ensure activity command fetches re-request buttons then favorite command labels
- add cache clearing helper coverage

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69336b2325c4832db3b79e918263a057)