### PR TITLE
Allow clear_entity_cache positional flags

### DIFF
--- a/custom_components/sofabaton_x1s/lib/x1_proxy.py
+++ b/custom_components/sofabaton_x1s/lib/x1_proxy.py
@@ -580,7 +580,6 @@ class X1Proxy:
     def clear_entity_cache(
         self,
         ent_id: int,
-        *,
         clear_buttons: bool = False,
         clear_favorites: bool = False,
     ) -> None:

--- a/tests/test_x1_proxy.py
+++ b/tests/test_x1_proxy.py
@@ -209,7 +209,7 @@ def test_clear_entity_cache_resets_all(monkeypatch) -> None:
     proxy._pending_command_requests[ent_lo] = {0xFF}
     proxy._pending_button_requests.add(ent_lo)
 
-    proxy.clear_entity_cache(ent_id, clear_buttons=True, clear_favorites=True)
+    proxy.clear_entity_cache(ent_id, True, True)
 
     assert ent_lo not in proxy.state.commands
     assert ent_lo not in proxy.state.buttons


### PR DESCRIPTION
## Summary
- allow `clear_entity_cache` to accept positional boolean arguments
- adjust proxy cache clearing test to cover positional usage

## Testing
- python -m pytest tests/test_x1_proxy.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693370130abc832dbdc0dc4439851d62)