### PR TITLE
Fix ensure_commands_for_activity call signature

### DIFF
--- a/custom_components/sofabaton_x1s/hub.py
+++ b/custom_components/sofabaton_x1s/hub.py
@@ -368,7 +368,9 @@ class SofabatonHub:
             await self._async_wait_for_buttons_ready(act_id)
 
         await self.hass.async_add_executor_job(
-            self._proxy.ensure_commands_for_activity, act_id, True
+            self._proxy.ensure_commands_for_activity,
+            act_id,
+            fetch_if_missing=True,
         )
 
     async def _async_fetch_device_commands(self, ent_id: int) -> None:


### PR DESCRIPTION
## Summary
- pass ensure_commands_for_activity arguments using keywords to match signature when fetching activity commands

## Testing
- pytest tests/test_x1_proxy.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693370f6ae20832d8f9f362e57815d9a)