### PR TITLE
Fix executor job keyword argument for activity command fetch

### DIFF
--- a/custom_components/sofabaton_x1s/hub.py
+++ b/custom_components/sofabaton_x1s/hub.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from functools import partial
 from typing import Any, Dict, Optional
 
 from homeassistant.components.zeroconf import async_get_instance
@@ -368,9 +369,11 @@ class SofabatonHub:
             await self._async_wait_for_buttons_ready(act_id)
 
         await self.hass.async_add_executor_job(
-            self._proxy.ensure_commands_for_activity,
-            act_id,
-            fetch_if_missing=True,
+            partial(
+                self._proxy.ensure_commands_for_activity,
+                act_id,
+                fetch_if_missing=True,
+            )
         )
 
     async def _async_fetch_device_commands(self, ent_id: int) -> None:


### PR DESCRIPTION
## Summary
- handle keyword arguments when scheduling ensure_commands_for_activity through async_add_executor_job
- import functools.partial for building executor call

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933723ef9e8832da212fc71afa41a0b)