### PR TITLE
Fix fetch device commands call signature

### DIFF
--- a/custom_components/sofabaton_x1s/hub.py
+++ b/custom_components/sofabaton_x1s/hub.py
@@ -386,7 +386,7 @@ class SofabatonHub:
         )
 
         await self.hass.async_add_executor_job(
-            self._proxy.get_commands_for_entity, ent_id, True
+            partial(self._proxy.get_commands_for_entity, ent_id, fetch_if_missing=True)
         )
 
     async def _async_wait_for_buttons_ready(self, ent_id: int) -> None:


### PR DESCRIPTION
## Summary
- fix executor job call to pass fetch_if_missing by keyword when fetching device commands
- prevent TypeError from positional arguments when retrieving commands

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693373e70798832db2c3a2c21fd8785b)