### PR TITLE
Parse favorite command ids from keymap responses

### DIFF
--- a/custom_components/sofabaton_x1s/lib/state_helpers.py
+++ b/custom_components/sofabaton_x1s/lib/state_helpers.py
@@ -68,7 +68,7 @@ class ActivityCache:
                     favorites_allowed = False
                     self.buttons[act_lo].add(button_id)
                 elif favorites_allowed:
-                    command_id = button_id  # simple command code used for label lookups
+                    command_id = payload[i + 9] if i + 10 <= n else button_id
                     self.activity_command_refs[act_lo].add((device_id, command_id))
                     self.activity_favorite_slots[act_lo].append(
                         {

--- a/tests/test_state_helpers.py
+++ b/tests/test_state_helpers.py
@@ -97,14 +97,14 @@ def test_accumulate_keymap_tracks_favorites_and_commands() -> None:
     cache.accumulate_keymap(act, rec_fav + rec_normal)
 
     refs = cache.get_activity_command_refs(act)
-    assert (0x03, favorite_button_id) in refs
-    assert (0x04, favorite_button_id) not in refs
+    assert (0x03, 0x03) in refs
+    assert (0x04, 0x03) not in refs
 
     favorite_slots = cache.get_activity_favorite_slots(act)
     assert any(
         slot["button_id"] == favorite_button_id
         and slot["device_id"] == 0x03
-        and slot["command_id"] == favorite_button_id
+        and slot["command_id"] == 0x03
         for slot in favorite_slots
     )
 
@@ -125,6 +125,6 @@ def test_accumulate_keymap_stops_at_standard_buttons() -> None:
     assert len(favorites) == 2
     assert {slot["button_id"] for slot in favorites} == {0x01, 0x02}
 
-    assert cache.get_activity_command_refs(act) == {(0x03, 0x01), (0x03, 0x02)}
+    assert cache.get_activity_command_refs(act) == {(0x03, 0x03), (0x03, 0x07)}
 
     assert cache.buttons.get(act, set()) == {0xAE}


### PR DESCRIPTION
## Summary
- parse favorite command identifiers from keymap favorite records
- add coverage for new req_buttons responses to ensure favorites capture the right device and command IDs
- update existing favorite parsing tests to reflect extracted command identifiers

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69337dc5f0c8832dbb772f81063a26a3)