### PR TITLE
Fix device ID detection for single command handler

### DIFF
--- a/custom_components/sofabaton_x1s/lib/commands.py
+++ b/custom_components/sofabaton_x1s/lib/commands.py
@@ -114,6 +114,13 @@ class DeviceCommandAssembler:
             return []
 
         dev_id = dev_id_override if dev_id_override is not None else payload[3]
+        if (
+            opcode == OP_DEVBTN_SINGLE
+            and dev_id_override is None
+            and payload[:6] == b"\x01\x00\x01\x01\x00\x01"
+            and len(payload) > 7
+        ):
+            dev_id = payload[7]
         frame_no = payload[2]
         burst = self._get_buffer(dev_id)
 

--- a/custom_components/sofabaton_x1s/lib/opcode_handlers.py
+++ b/custom_components/sofabaton_x1s/lib/opcode_handlers.py
@@ -240,6 +240,13 @@ def _infer_command_entity(proxy: "X1Proxy", payload: bytes) -> int:
 def _extract_dev_id(raw: bytes, payload: bytes, opcode: int) -> int:
     """Determine device ID for a command burst frame."""
 
+    if (
+        opcode == OP_DEVBTN_SINGLE
+        and len(payload) > 7
+        and payload[:6] == b"\x01\x00\x01\x01\x00\x01"
+    ):
+        return payload[7]
+
     if opcode in (OP_DEVBTN_HEADER, OP_DEVBTN_PAGE_ALT1) and len(raw) > 11:
         return raw[11]
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,6 +3,8 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -110,15 +112,104 @@ def test_single_command_handler_logs_and_stores_state(caplog) -> None:
     assert "1 : Exit" in caplog.text
 
 
-def test_parse_device_commands_realigns_utf16_label() -> None:
+@pytest.mark.parametrize(
+    ("raw_hex", "expected_dev_id", "expected_cmd_id", "expected_label"),
+    [
+        (
+            "a5 5a 4d 5d 01 00 01 01 00 01 01 06 01 0d 00 00 00 00 00 2a 00 4f 00 6b 00 "
+            + "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
+            + "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
+            + "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ff a5",
+            6,
+            1,
+            "Ok",
+        ),
+        (
+            "a5 5a 4d 5d 01 00 01 01 00 01 01 03 03 0d 00 00 00 00 00 38 00 30 00 "
+            + "00 " * 57
+            + "ff 28",
+            3,
+            3,
+            "0",
+        ),
+        (
+            "a5 5a 4d 5d 01 00 01 01 00 01 01 03 07 0d 00 00 00 00 00 4c 00 34 00 "
+            + "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
+            + "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
+            + "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ff 44",
+            3,
+            7,
+            "4",
+        ),
+    ],
+)
+def test_device_button_single_handler_uses_device_id_from_payload(
+    caplog: pytest.LogCaptureFixture,
+    raw_hex: str,
+    expected_dev_id: int,
+    expected_cmd_id: int,
+    expected_label: str,
+) -> None:
+    proxy = X1Proxy("127.0.0.1")
+    handler = DeviceButtonSingleHandler()
+
+    raw = bytes.fromhex(raw_hex)
+    payload = raw[4:-1]
+
+    frame = FrameContext(
+        proxy=proxy,
+        opcode=OP_DEVBTN_SINGLE,
+        direction="H→A",
+        payload=payload,
+        raw=raw,
+        name="DEVBTN_SINGLE",
+    )
+
+    with caplog.at_level(logging.INFO):
+        handler.handle(frame)
+
+    assert proxy.state.commands[expected_dev_id] == {expected_cmd_id: expected_label}
+    assert f"{expected_cmd_id} : {expected_label}" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("raw_hex", "expected_dev_id", "expected_cmd_id", "expected_label"),
+    [
+        (
+            "a5 5a 4d 5d 01 00 01 01 00 01 01 06 01 0d 00 00 00 00 00 2a 00 4f 00 6b 00 "
+            + "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
+            + "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
+            + "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ff a5",
+            6,
+            1,
+            "Ok",
+        ),
+        (
+            "a5 5a 4d 5d 01 00 01 01 00 01 01 03 03 0d 00 00 00 00 00 38 00 30 00 "
+            + "00 " * 57
+            + "ff 28",
+            3,
+            3,
+            "0",
+        ),
+        (
+            "a5 5a 4d 5d 01 00 01 01 00 01 01 03 07 0d 00 00 00 00 00 4c 00 34 00 "
+            + "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
+            + "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
+            + "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ff 44",
+            3,
+            7,
+            "4",
+        ),
+    ],
+)
+def test_parse_device_commands_realigns_utf16_label(
+    raw_hex: str, expected_dev_id: int, expected_cmd_id: int, expected_label: str
+) -> None:
     proxy = X1Proxy("127.0.0.1")
     assembler = proxy._command_assembler
 
-    raw = bytes.fromhex(
-        "a5 5a 4d 5d 01 00 01 01 00 01 01 03 03 0d 00 00 00 00 00 38 00 30 00 "
-        + "00 " * 57
-        + "ff 28"
-    )
+    raw = bytes.fromhex(raw_hex)
 
     opcode = int.from_bytes(raw[2:4], "big")
     completed = assembler.feed(opcode, raw)
@@ -128,7 +219,8 @@ def test_parse_device_commands_realigns_utf16_label() -> None:
 
     parsed = proxy.parse_device_commands(payload, dev_id)
 
-    assert parsed == {3: "0"}
+    assert dev_id == expected_dev_id
+    assert parsed == {expected_cmd_id: expected_label}
 
 
 def test_parse_device_commands_handles_legacy_and_hue_formats() -> None:


### PR DESCRIPTION
## Summary
- extract device IDs from single-command payloads using the observed layout
- add handler tests covering additional UTF-16 single-command frames to ensure state storage

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69338513f27c832da121675801a5a40e)