### PR TITLE
Handle favorite labels separately in index sensor

### DIFF
--- a/custom_components/sofabaton_x1s/hub.py
+++ b/custom_components/sofabaton_x1s/hub.py
@@ -421,6 +421,8 @@ class SofabatonHub:
         if clear_favorites:
             self._proxy.state.activity_command_refs.pop(ent_id & 0xFF, None)
             self._proxy.state.activity_favorite_slots.pop(ent_id & 0xFF, None)
+            self._proxy.state.activity_favorite_labels.pop(ent_id & 0xFF, None)
+            self._proxy._clear_favorite_label_requests_for_activity(ent_id & 0xFF)
 
     async def _async_prime_buttons_for(self, act_id: int) -> None:
         # dedupe here
@@ -493,6 +495,18 @@ class SofabatonHub:
             if ready and cmds:
                 result[ent_id] = cmds
         return result
+
+    def get_activity_favorites(self) -> dict[int, list[dict[str, int | str]]]:
+        """Return favorite commands with labels for activities."""
+
+        favorites: dict[int, list[dict[str, int | str]]] = {}
+
+        for act_id in self.activities:
+            labels = self._proxy.state.get_activity_favorite_labels(act_id & 0xFF)
+            if labels:
+                favorites[act_id] = labels
+
+        return favorites
 
     def get_app_activations(self) -> list[dict[str, Any]]:
         """Return recent app-originated activation requests."""

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -112,6 +112,34 @@ def test_single_command_handler_logs_and_stores_state(caplog) -> None:
     assert "1 : Exit" in caplog.text
 
 
+def test_single_command_handler_routes_favorite_labels() -> None:
+    proxy = X1Proxy("127.0.0.1")
+    handler = DeviceButtonSingleHandler()
+
+    proxy._favorite_label_requests[(1, 1)] = {0x66}
+
+    raw = bytes.fromhex(
+        "a5 5a 4d 5d 01 00 01 01 00 01 01 01 02 0d 00 00 00 00 00 79 00 45 00 78 00 69 00 74 00 00 00 00 00 "
+        "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
+        "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ff d0"
+    )
+
+    payload = raw[4:-1]
+    frame = FrameContext(
+        proxy=proxy,
+        opcode=OP_DEVBTN_SINGLE,
+        direction="H→A",
+        payload=payload,
+        raw=raw,
+        name="DEVBTN_SINGLE",
+    )
+
+    handler.handle(frame)
+
+    assert proxy.state.commands == {}
+    assert proxy.state.activity_favorite_labels[0x66] == {(1, 1): "Exit"}
+
+
 @pytest.mark.parametrize(
     ("raw_hex", "expected_dev_id", "expected_cmd_id", "expected_label"),
     [

--- a/tests/test_state_helpers.py
+++ b/tests/test_state_helpers.py
@@ -128,3 +128,23 @@ def test_accumulate_keymap_stops_at_standard_buttons() -> None:
     assert cache.get_activity_command_refs(act) == {(0x03, 0x03), (0x03, 0x07)}
 
     assert cache.buttons.get(act, set()) == {0xAE}
+
+
+def test_activity_favorite_labels_with_slots() -> None:
+    cache = ActivityCache()
+    act = 0x21
+
+    cache.activity_favorite_slots[act] = [
+        {"button_id": 0xFE, "device_id": 0x10, "command_id": 0x05},
+        {"button_id": 0xFD, "device_id": 0x11, "command_id": 0x06},
+    ]
+
+    cache.record_favorite_label(act, 0x10, 0x05, "Fav One")
+    cache.record_favorite_label(act, 0x11, 0x06, "Fav Two")
+
+    favorites = cache.get_activity_favorite_labels(act)
+
+    assert favorites == [
+        {"name": "Fav One", "device_id": 0x10, "command_id": 0x05},
+        {"name": "Fav Two", "device_id": 0x11, "command_id": 0x06},
+    ]

--- a/tests/test_x1_proxy.py
+++ b/tests/test_x1_proxy.py
@@ -42,6 +42,12 @@ def test_ensure_commands_for_activity_groups_favorites(monkeypatch) -> None:
         0x01: {0x1111: "one", 0x2222: "two"},
         0x02: {0x3333: "three"},
     }
+    assert proxy.state.activity_favorite_labels[act] == {
+        (0x01, 0x1111): "one",
+        (0x01, 0x2222): "two",
+        (0x02, 0x3333): "three",
+    }
+    assert proxy._favorite_label_requests == {(0x01, 0x2222): {act}}
 
 
 def test_ensure_commands_for_activity_only_favorites(monkeypatch) -> None:
@@ -75,6 +81,10 @@ def test_ensure_commands_for_activity_only_favorites(monkeypatch) -> None:
         (0x03, 0xCCCC, True),
     }
     assert commands_by_device == {0x01: {0xAAAA: "alpha"}, 0x03: {0xCCCC: "charlie"}}
+    assert proxy.state.activity_favorite_labels[act] == {
+        (0x01, 0xAAAA): "alpha",
+        (0x03, 0xCCCC): "charlie",
+    }
 
 
 def test_ensure_commands_for_activity_without_favorites_does_nothing(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- stop exposing live status and button data from the index sensor while adding activity favorite details
- separate activity favorite command labels from device command caches and surface them on the index sensor
- ensure favorite label fetches do not populate device command listings and add supporting tests

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934af4c97d8832d8da79a84b6582afd)