### PR TITLE
Add macro burst handling for activities

### DIFF
--- a/custom_components/sofabaton_x1s/lib/protocol_const.py
+++ b/custom_components/sofabaton_x1s/lib/protocol_const.py
@@ -100,7 +100,8 @@ OP_CALL_ME = 0x0CC3
 # noise we're not using (kept for reference)
 OP_REQ_VERSION = 0x0058  # yields WIFI_FW (0x0359) then INFO_BANNER (0x112F)
 OP_PING2 = 0x0140
-OP_REQ_MACROS = 0x024D  # payload: [act_lo, 0xFF]
+OP_REQ_MACRO_LABELS = 0x024D  # payload: [act_lo, 0xFF]
+OP_REQ_MACROS = OP_REQ_MACRO_LABELS  # backward-compat alias
 OP_MACROS_A1 = 0x6E13
 OP_MACROS_B1 = 0x5A13
 OP_MACROS_A2 = 0x8213
@@ -164,7 +165,7 @@ OPNAMES: Dict[int, str] = {
     OP_MACROS_B1: "MACROS_B1",
     OP_MACROS_A2: "MACROS_A2",
     OP_MACROS_B2: "MACROS_B2",
-    OP_REQ_MACROS: "REQ_MACROS",
+    OP_REQ_MACRO_LABELS: "REQ_MACRO_LABELS",
     OP_REQ_VERSION: "REQ_VERSION",
     OP_PING2: "PING2",
 }
@@ -262,7 +263,7 @@ __all__ = [
     "OP_CALL_ME",
     "OP_REQ_VERSION",
     "OP_PING2",
-    "OP_REQ_MACROS",
+    "OP_REQ_MACRO_LABELS",
     "OP_MACROS_A1",
     "OP_MACROS_B1",
     "OP_MACROS_A2",


### PR DESCRIPTION
## Summary
- queue macro label requests alongside activity button/command fetches using the updated opcode and burst tracking
- track macro readiness in the hub so command loading state and dispatcher signals reflect completion
- expose proxy helpers to retrieve cached macros with ready flags and cache clearing support

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935e94e646c832d867b732a4c1b8d19)