### PR TITLE
Disable IP address text entity by default

### DIFF
--- a/custom_components/sofabaton_x1s/text.py
+++ b/custom_components/sofabaton_x1s/text.py
@@ -29,6 +29,7 @@ class SofabatonHubIpText(TextEntity):
     _attr_should_poll = False
     _attr_entity_category = EntityCategory.CONFIG
     _attr_icon = "mdi:ip"
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, hub: SofabatonHub, entry: ConfigEntry) -> None:
         self._hub = hub


### PR DESCRIPTION
## Summary
- disable the hub IP address text entity by default so it must be manually enabled before use

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936083b65a4832d95ca38d14912e20e)