### PR TITLE
Support Sofabaton discovery across both mDNS service names

### DIFF
--- a/custom_components/sofabaton_x1s/const.py
+++ b/custom_components/sofabaton_x1s/const.py
@@ -1,7 +1,11 @@
 # const.py
 DOMAIN = "sofabaton_x1s"
 
-MDNS_TYPE = "_x1hub._udp.local."
+MDNS_SERVICE_TYPES: tuple[str, ...] = (
+    "_x1hub._udp.local.",
+    "_sofabaton_hub._udp.local.",
+)
+PRIMARY_MDNS_TYPE = MDNS_SERVICE_TYPES[0]
 CONF_MAC = "mac"
 CONF_HOST = "host"
 CONF_PORT = "port"

--- a/custom_components/sofabaton_x1s/lib/x1_proxy.py
+++ b/custom_components/sofabaton_x1s/lib/x1_proxy.py
@@ -11,6 +11,7 @@ import time
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple
 
+from ..const import PRIMARY_MDNS_TYPE
 from .frame_handlers import FrameContext, frame_handler_registry
 from .commands import DeviceCommandAssembler
 from .macros import MacroAssembler
@@ -962,7 +963,7 @@ class X1Proxy:
         from zeroconf import Zeroconf, ServiceInfo, IPVersion
 
         ip_bytes = socket.inet_aton(_route_local_ip(self.real_hub_ip))
-        service_type = "_x1hub._udp.local."
+        service_type = PRIMARY_MDNS_TYPE
         instance = self.mdns_instance
         host = (self.mdns_host or instance) + "."
 

--- a/custom_components/sofabaton_x1s/manifest.json
+++ b/custom_components/sofabaton_x1s/manifest.json
@@ -13,6 +13,9 @@
   "zeroconf": [
     {
       "type": "_x1hub._udp.local."
+    },
+    {
+      "type": "_sofabaton_hub._udp.local."
     }
   ]
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,22 @@ from pathlib import Path
 
 
 def _install_homeassistant_stubs() -> None:
+    vol = types.ModuleType("voluptuous")
+
+    class _Schema:  # pragma: no cover - only used as stub
+        def __init__(self, schema=None, **kwargs) -> None:
+            self.schema = schema
+            self.kwargs = kwargs
+
+        def __call__(self, *args, **kwargs):
+            return self
+
+    vol.Schema = _Schema
+    vol.Required = lambda key, default=None: key  # type: ignore[assignment]
+    vol.All = lambda *args, **kwargs: args  # type: ignore[assignment]
+    vol.Range = lambda **kwargs: kwargs  # type: ignore[assignment]
+    sys.modules.setdefault("voluptuous", vol)
+
     ha = types.ModuleType("homeassistant")
     sys.modules.setdefault("homeassistant", ha)
 
@@ -12,7 +28,41 @@ def _install_homeassistant_stubs() -> None:
     class ConfigEntry:  # pragma: no cover - only used as stub
         pass
 
+    class ConfigFlow:  # pragma: no cover - only used as stub
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__()
+
+        async def async_set_unique_id(self, *args, **kwargs):
+            return None
+
+        def _abort_if_unique_id_configured(self, *args, **kwargs):
+            return False
+
+        def async_show_form(self, *args, **kwargs):
+            return {"type": "form", **kwargs}
+
+        def async_abort(self, *args, **kwargs):
+            return {"type": "abort", **kwargs}
+
+        def async_create_entry(self, *args, **kwargs):
+            return {"type": "create_entry", **kwargs}
+
+        def _async_current_entries(self):
+            return []
+
+    class OptionsFlow:  # pragma: no cover - only used as stub
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__()
+
+        def async_show_form(self, *args, **kwargs):
+            return {"type": "form", **kwargs}
+
+        def async_create_entry(self, *args, **kwargs):
+            return {"type": "create_entry", **kwargs}
+
     config_entries.ConfigEntry = ConfigEntry
+    config_entries.ConfigFlow = ConfigFlow
+    config_entries.OptionsFlow = OptionsFlow
     sys.modules.setdefault("homeassistant.config_entries", config_entries)
 
     core = types.ModuleType("homeassistant.core")
@@ -25,10 +75,35 @@ def _install_homeassistant_stubs() -> None:
 
     core.HomeAssistant = HomeAssistant
     core.ServiceCall = ServiceCall
+    core.callback = lambda func: func  # type: ignore[assignment]
     sys.modules.setdefault("homeassistant.core", core)
 
     helpers = types.ModuleType("homeassistant.helpers")
     sys.modules.setdefault("homeassistant.helpers", helpers)
+
+    service_info = types.ModuleType("homeassistant.helpers.service_info")
+    sys.modules.setdefault("homeassistant.helpers.service_info", service_info)
+
+    zeroconf_service_info = types.ModuleType("homeassistant.helpers.service_info.zeroconf")
+
+    class ZeroconfServiceInfo:  # pragma: no cover - only used as stub
+        def __init__(
+            self,
+            *,
+            host: str | None = None,
+            port: int | None = None,
+            name: str | None = None,
+            properties: dict | None = None,
+            type: str | None = None,
+        ) -> None:
+            self.host = host
+            self.port = port
+            self.name = name
+            self.properties = properties
+            self.type = type
+
+    zeroconf_service_info.ZeroconfServiceInfo = ZeroconfServiceInfo
+    sys.modules.setdefault("homeassistant.helpers.service_info.zeroconf", zeroconf_service_info)
 
     dispatcher = types.ModuleType("homeassistant.helpers.dispatcher")
     dispatcher.async_dispatcher_send = lambda hass=None, signal=None, *args, **kwargs: None

--- a/tests/test_config_flow_discovery.py
+++ b/tests/test_config_flow_discovery.py
@@ -1,0 +1,60 @@
+import pytest
+
+from custom_components.sofabaton_x1s.config_flow import _prepare_discovered_hub
+from custom_components.sofabaton_x1s.const import MDNS_SERVICE_TYPES
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+
+
+def _service_info(service_type: str, **kwargs) -> ZeroconfServiceInfo:
+    return ZeroconfServiceInfo(
+        host=kwargs.get("host", "1.2.3.4"),
+        port=kwargs.get("port", 8102),
+        name=kwargs.get("name", "X1-HUB._x1hub._udp.local."),
+        properties=kwargs.get("properties", {}),
+        type=service_type,
+    )
+
+
+@pytest.mark.parametrize("service_type", MDNS_SERVICE_TYPES)
+def test_prepare_discovered_hub_accepts_supported_service_types(service_type: str) -> None:
+    info = _service_info(
+        service_type,
+        properties={
+            "NAME": b"Sofa Hub",
+            "MAC": b"aa:bb:cc:dd:ee:ff",
+            "NO": b"20230000",
+        },
+    )
+
+    result = _prepare_discovered_hub(info)
+
+    assert result is not None
+    assert result["name"] == "Sofa Hub"
+    assert result["mac"] == "aa:bb:cc:dd:ee:ff"
+    assert result["host"] == "1.2.3.4"
+    assert result["port"] == 8102
+    assert result["props"]["NAME"] == "Sofa Hub"
+    assert result["service_type"] == service_type
+    assert result["version"] == "X1S"
+
+
+def test_prepare_discovered_hub_rejects_unsupported_service_type() -> None:
+    result = _prepare_discovered_hub(
+        _service_info(
+            "_unsupported._udp.local.",
+            properties={"NAME": "Hub"},
+        )
+    )
+
+    assert result is None
+
+
+def test_prepare_discovered_hub_rejects_proxy_advertisement() -> None:
+    result = _prepare_discovered_hub(
+        _service_info(
+            MDNS_SERVICE_TYPES[0],
+            properties={"HA_PROXY": "1"},
+        )
+    )
+
+    assert result is None


### PR DESCRIPTION
## Summary
- include both Sofabaton hub mDNS service types in the zeroconf manifest and constants
- normalize zeroconf discovery handling so the flow accepts either service type while rejecting proxy adverts
- extend local stubs and add tests that cover zeroconf parsing for both service names

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695911b3df2c832d80412d0e62bfbb75)