### PR TITLE
Advertise Sofabaton mDNS type based on hub version

### DIFF
--- a/custom_components/sofabaton_x1s/config_flow.py
+++ b/custom_components/sofabaton_x1s/config_flow.py
@@ -21,25 +21,10 @@ from .const import (
     DEFAULT_PROXY_UDP_PORT,
     DEFAULT_HUB_LISTEN_BASE,
     MDNS_SERVICE_TYPES,
-    X1S_NO_THRESHOLD,
+    classify_hub_version,
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _classify_version(props: Dict[str, str]) -> str:
-    no_field = props.get("NO")
-    if no_field is not None:
-        try:
-            no_value = int(str(no_field))
-        except ValueError:
-            pass
-        else:
-            if no_value >= X1S_NO_THRESHOLD:
-                return "X1S"
-            return "X1"
-
-    return "X1"
 
 
 def generate_static_mac(host: str, port: int) -> str:
@@ -79,7 +64,7 @@ def _prepare_discovered_hub(discovery_info: ZeroconfServiceInfo) -> Dict[str, An
 
     name = props.get("NAME") or discovery_info.name.split(".")[0]
     mac = props.get("MAC") or discovery_info.name
-    version = _classify_version(props)
+    version = classify_hub_version(props)
     no_field = props.get("NO")
 
     return {
@@ -176,7 +161,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured()
 
             # build data
-            version = hub_info.get("version") or _classify_version(hub_info.get("props", {}))
+            version = hub_info.get("version") or classify_hub_version(hub_info.get("props", {}))
             data = {
                 CONF_MAC: mac,
                 CONF_NAME: hub_info["name"],
@@ -388,5 +373,4 @@ class SofabatonOptionsFlowHandler(config_entries.OptionsFlow):
                 )
             },
         )
-
 

--- a/custom_components/sofabaton_x1s/const.py
+++ b/custom_components/sofabaton_x1s/const.py
@@ -5,7 +5,8 @@ MDNS_SERVICE_TYPES: tuple[str, ...] = (
     "_x1hub._udp.local.",
     "_sofabaton_hub._udp.local.",
 )
-PRIMARY_MDNS_TYPE = MDNS_SERVICE_TYPES[0]
+MDNS_SERVICE_TYPE_X1 = MDNS_SERVICE_TYPES[0]
+MDNS_SERVICE_TYPE_X2 = MDNS_SERVICE_TYPES[1]
 CONF_MAC = "mac"
 CONF_HOST = "host"
 CONF_PORT = "port"
@@ -14,6 +15,28 @@ CONF_MDNS_TXT = "mdns_txt"
 CONF_MDNS_VERSION = "mdns_version"
 CONF_PROXY_ENABLED = "proxy_enabled"
 CONF_HEX_LOGGING_ENABLED = "hex_logging_enabled"
+
+# Hub version classification
+HVER_X1 = "1"
+HVER_X1S = "2"
+HVER_X2 = "3"
+
+HUB_VERSION_X1 = "X1"
+HUB_VERSION_X1S = "X1S"
+HUB_VERSION_X2 = "X2"
+DEFAULT_HUB_VERSION = HUB_VERSION_X1
+
+HUB_VERSION_BY_HVER = {
+    HVER_X1: HUB_VERSION_X1,
+    HVER_X1S: HUB_VERSION_X1S,
+    HVER_X2: HUB_VERSION_X2,
+}
+
+MDNS_SERVICE_TYPE_BY_VERSION = {
+    HUB_VERSION_X1: MDNS_SERVICE_TYPE_X1,
+    HUB_VERSION_X1S: MDNS_SERVICE_TYPE_X1,
+    HUB_VERSION_X2: MDNS_SERVICE_TYPE_X2,
+}
 
 # X1S devices report a higher NO field in their mDNS TXT records
 X1S_NO_THRESHOLD = 20221120
@@ -62,3 +85,33 @@ def signal_macros(entry_id: str) -> str:
 
 def signal_app_activations(entry_id: str) -> str:
     return f"sofabaton_x1s_app_activations_{entry_id}"
+
+
+def classify_hub_version(props: dict[str, str]) -> str:
+    """Determine hub version based on advertised properties."""
+
+    hver = props.get("HVER")
+    if hver is not None:
+        version = HUB_VERSION_BY_HVER.get(str(hver).strip())
+        if version:
+            return version
+
+    no_field = props.get("NO")
+    if no_field is not None:
+        try:
+            no_value = int(str(no_field))
+        except ValueError:
+            pass
+        else:
+            if no_value >= X1S_NO_THRESHOLD:
+                return HUB_VERSION_X1S
+            return HUB_VERSION_X1
+
+    return DEFAULT_HUB_VERSION
+
+
+def mdns_service_type_for_props(props: dict[str, str]) -> str:
+    """Map hub properties to the correct mDNS service type."""
+
+    version = classify_hub_version(props)
+    return MDNS_SERVICE_TYPE_BY_VERSION.get(version, MDNS_SERVICE_TYPE_X1)

--- a/tests/test_config_flow_discovery.py
+++ b/tests/test_config_flow_discovery.py
@@ -15,14 +15,22 @@ def _service_info(service_type: str, **kwargs) -> ZeroconfServiceInfo:
     )
 
 
-@pytest.mark.parametrize("service_type", MDNS_SERVICE_TYPES)
-def test_prepare_discovered_hub_accepts_supported_service_types(service_type: str) -> None:
+@pytest.mark.parametrize(
+    ("service_type", "hver", "expected_version"),
+    [
+        (MDNS_SERVICE_TYPES[0], "1", "X1"),
+        (MDNS_SERVICE_TYPES[1], "3", "X2"),
+    ],
+)
+def test_prepare_discovered_hub_accepts_supported_service_types(
+    service_type: str, hver: str, expected_version: str
+) -> None:
     info = _service_info(
         service_type,
         properties={
             "NAME": b"Sofa Hub",
             "MAC": b"aa:bb:cc:dd:ee:ff",
-            "NO": b"20230000",
+            "HVER": hver.encode(),
         },
     )
 
@@ -35,7 +43,7 @@ def test_prepare_discovered_hub_accepts_supported_service_types(service_type: st
     assert result["port"] == 8102
     assert result["props"]["NAME"] == "Sofa Hub"
     assert result["service_type"] == service_type
-    assert result["version"] == "X1S"
+    assert result["version"] == expected_version
 
 
 def test_prepare_discovered_hub_rejects_unsupported_service_type() -> None:


### PR DESCRIPTION
## Summary
- classify hub version primarily from HVER and map versions to correct service types
- advertise a single mDNS service matching the connected hub (X1/X1S vs X2) while keeping TXT data and teardown tracking intact
- update zeroconf discovery tests to reflect HVER-based version detection

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69591a3382c0832d805e9abf83c22a97)