### PR TITLE
Always advertise legacy x1 mDNS service

### DIFF
--- a/custom_components/sofabaton_x1s/const.py
+++ b/custom_components/sofabaton_x1s/const.py
@@ -35,7 +35,8 @@ HUB_VERSION_BY_HVER = {
 MDNS_SERVICE_TYPE_BY_VERSION = {
     HUB_VERSION_X1: MDNS_SERVICE_TYPE_X1,
     HUB_VERSION_X1S: MDNS_SERVICE_TYPE_X1,
-    HUB_VERSION_X2: MDNS_SERVICE_TYPE_X2,
+    # X2 hubs continue to use the legacy _x1hub._udp.local. advertisement for compatibility
+    HUB_VERSION_X2: MDNS_SERVICE_TYPE_X1,
 }
 
 # X1S devices report a higher NO field in their mDNS TXT records


### PR DESCRIPTION
## Summary
- keep hub version classification while mapping all hubs to the legacy _x1hub._udp.local. advertisement
- add a regression test to ensure X2 hubs still register the x1 mDNS service

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a5a2df960832db50f2fa26995d6b1)