### PR TITLE
Add X2 button support

### DIFF
--- a/custom_components/sofabaton_x1s/__init__.py
+++ b/custom_components/sofabaton_x1s/__init__.py
@@ -16,6 +16,7 @@ from .const import (
     CONF_MAC,
     CONF_PROXY_ENABLED,
     CONF_HEX_LOGGING_ENABLED,
+    CONF_MDNS_VERSION,
 )
 from .diagnostics import (
     async_disable_hex_logging_capture,
@@ -37,6 +38,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hub_listen_base = opts.get("hub_listen_base", DEFAULT_HUB_LISTEN_BASE)
     proxy_enabled = opts.get(CONF_PROXY_ENABLED, True)
     hex_logging_enabled = opts.get(CONF_HEX_LOGGING_ENABLED, False)
+    version = data.get(CONF_MDNS_VERSION) or opts.get(CONF_MDNS_VERSION)
     hub = SofabatonHub(
         hass=hass,
         entry_id=entry.entry_id,
@@ -48,6 +50,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hub_listen_base=hub_listen_base,
         proxy_enabled=proxy_enabled,
         hex_logging_enabled=hex_logging_enabled,
+        version=version,
     )
     await hub.async_start()
 

--- a/custom_components/sofabaton_x1s/button.py
+++ b/custom_components/sofabaton_x1s/button.py
@@ -13,6 +13,7 @@ from .const import (
     DOMAIN,
     CONF_MAC,
     CONF_NAME,
+    HUB_VERSION_X2,
     signal_activity,
     signal_buttons,
     signal_client,
@@ -24,7 +25,7 @@ from .lib.protocol_const import ButtonName  # your proxy enum
 _LOGGER = logging.getLogger(__name__)
 
 # Fixed, explicit list so HA doesn't invent weird entities
-BUTTON_DEFS = [
+BUTTON_DEFS_X1 = [
     (ButtonName.BACK, "Back", "mdi:keyboard-backspace"),
     (ButtonName.BLUE, "Blue button", "mdi:circle"),
     (ButtonName.CH_DOWN, "Channel down", "mdi:arrow-down-bold-box"),
@@ -50,7 +51,19 @@ BUTTON_DEFS = [
 ]
 
 # sort them nicely
-BUTTON_DEFS.sort(key=lambda x: x[1].lower())
+BUTTON_DEFS_X1.sort(key=lambda x: x[1].lower())
+
+BUTTON_DEFS_X2 = BUTTON_DEFS_X1 + [
+    (ButtonName.GUIDE, "Guide", "mdi:television-guide"),
+    (ButtonName.DVR, "DVR", "mdi:filmstrip"),
+    (ButtonName.EXIT, "Exit", "mdi:exit-to-app"),
+    (ButtonName.PLAY, "Play", "mdi:play"),
+    (ButtonName.A, "A button", "mdi:alpha-a-circle"),
+    (ButtonName.B, "B button", "mdi:alpha-b-circle"),
+    (ButtonName.C, "C button", "mdi:alpha-c-circle"),
+]
+
+BUTTON_DEFS_X2.sort(key=lambda x: x[1].lower())
 
 
 async def async_setup_entry(
@@ -60,8 +73,14 @@ async def async_setup_entry(
 ) -> None:
     hub: SofabatonHub = hass.data[DOMAIN][entry.entry_id]
 
+    version = getattr(hub, "version", None)
+    if version == HUB_VERSION_X2:
+        button_defs = BUTTON_DEFS_X2
+    else:
+        button_defs = BUTTON_DEFS_X1
+
     entities: list[ButtonEntity] = [SofabatonFindRemoteButton(hub, entry)]
-    for code, label, icon in BUTTON_DEFS:
+    for code, label, icon in button_defs:
         entities.append(SofabatonDynamicButton(hub, entry, code, label, icon))
 
     async_add_entities(entities)

--- a/custom_components/sofabaton_x1s/hub.py
+++ b/custom_components/sofabaton_x1s/hub.py
@@ -53,6 +53,7 @@ class SofabatonHub:
         hub_listen_base: int,
         proxy_enabled: bool,
         hex_logging_enabled: bool,
+        version: str | None = None,
     ) -> None:
         self.hass = hass
         self.entry_id = entry_id
@@ -61,6 +62,7 @@ class SofabatonHub:
         self.port = port
         self.mdns_txt = mdns_txt
         self.mdns_txt["HA_PROXY"] = "1"
+        self.version = version
 
         self._proxy_udp_port = proxy_udp_port
         self._hub_listen_base = hub_listen_base

--- a/custom_components/sofabaton_x1s/lib/protocol_const.py
+++ b/custom_components/sofabaton_x1s/lib/protocol_const.py
@@ -11,6 +11,16 @@ SYNC0, SYNC1 = 0xA5, 0x5A
 class ButtonName:
     """Enumeration of known Sofabaton button codes."""
 
+    # X2-only / extended keys (below 0xAE)
+    C = 0x97
+    B = 0x98
+    A = 0x99
+    EXIT = 0x9A
+    DVR = 0x9B
+    PLAY = 0x9C
+    GUIDE = 0x9D
+
+    # Shared X1/X1S/X2 keys (existing)
     UP = 0xAE
     DOWN = 0xB2
     LEFT = 0xAF


### PR DESCRIPTION
## Summary
- add X2-only button codes to the protocol constants and button entity sets
- pass hub version into SofabatonHub and select button entities based on hub type
- keep X1/X1S behavior unchanged while enabling X2-specific button entities

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a6be29010832db20d583bd2dbce04)