### PR TITLE
Add manual hub version selection

### DIFF
--- a/custom_components/sofabaton_x1s/const.py
+++ b/custom_components/sofabaton_x1s/const.py
@@ -39,9 +39,6 @@ MDNS_SERVICE_TYPE_BY_VERSION = {
     HUB_VERSION_X2: MDNS_SERVICE_TYPE_X1,
 }
 
-# X1S devices report a higher NO field in their mDNS TXT records
-X1S_NO_THRESHOLD = 20221120
-
 DEFAULT_PROXY_UDP_PORT = 8102
 DEFAULT_HUB_LISTEN_BASE = 8200
 
@@ -96,17 +93,6 @@ def classify_hub_version(props: dict[str, str]) -> str:
         version = HUB_VERSION_BY_HVER.get(str(hver).strip())
         if version:
             return version
-
-    no_field = props.get("NO")
-    if no_field is not None:
-        try:
-            no_value = int(str(no_field))
-        except ValueError:
-            pass
-        else:
-            if no_value >= X1S_NO_THRESHOLD:
-                return HUB_VERSION_X1S
-            return HUB_VERSION_X1
 
     return DEFAULT_HUB_VERSION
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ def _install_homeassistant_stubs() -> None:
     vol.Required = lambda key, default=None: key  # type: ignore[assignment]
     vol.All = lambda *args, **kwargs: args  # type: ignore[assignment]
     vol.Range = lambda **kwargs: kwargs  # type: ignore[assignment]
+    vol.In = lambda *args, **kwargs: args  # type: ignore[assignment]
     sys.modules.setdefault("voluptuous", vol)
 
     ha = types.ModuleType("homeassistant")


### PR DESCRIPTION
## Summary
- remove legacy NO-based hub version inference logic
- add manual configuration support for selecting hub version and expose the field in options
- update test stubs and coverage for the new configuration field

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af4efff24832db25032ba73c5df1d)