### PR TITLE
Make mDNS version immutable in options flow

### DIFF
--- a/custom_components/sofabaton_x1s/config_flow.py
+++ b/custom_components/sofabaton_x1s/config_flow.py
@@ -347,7 +347,6 @@ class SofabatonOptionsFlowHandler(config_entries.OptionsFlow):
             new_options = {
                 **self.entry.options,
                 **user_input,
-                CONF_MDNS_VERSION: user_input.get(CONF_MDNS_VERSION),
             }
             self.hass.config_entries.async_update_entry(
                 self.entry,
@@ -367,13 +366,6 @@ class SofabatonOptionsFlowHandler(config_entries.OptionsFlow):
                 "hub_listen_base",
                 default=self.entry.options.get("hub_listen_base", DEFAULT_HUB_LISTEN_BASE),
             ): PORT_VALIDATOR,
-            vol.Required(
-                CONF_MDNS_VERSION,
-                default=self.entry.options.get(
-                    CONF_MDNS_VERSION,
-                    self.entry.data.get(CONF_MDNS_VERSION, DEFAULT_HUB_VERSION),
-                ),
-            ): vol.In([HUB_VERSION_X1, HUB_VERSION_X1S, HUB_VERSION_X2]),
         })
 
         return self.async_show_form(

--- a/custom_components/sofabaton_x1s/translations/en.json
+++ b/custom_components/sofabaton_x1s/translations/en.json
@@ -10,7 +10,8 @@
         "description": "Provide a name and IP address for your Sofabaton hub. The name you choose here will become the name of your virtual hub and cannot be changed later.",
         "data": {
           "name": "Hub name",
-          "host": "Hub IP address"
+          "host": "Hub IP address",
+          "mdns_version": "Hub model (select X1 if unsure)"
         }
       },
       "ports": {


### PR DESCRIPTION
## Summary
- remove the mDNS version selector from the options flow so the hub model stays fixed after setup
- add a manual setup label for choosing the mDNS version

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b08771728832dad56c778880520ba)