### PR TITLE
Handle X2 find remote command

### DIFF
--- a/custom_components/sofabaton_x1s/hub.py
+++ b/custom_components/sofabaton_x1s/hub.py
@@ -663,7 +663,7 @@ class SofabatonHub:
 
     async def async_find_remote(self) -> None:
         _LOGGER.debug("[%s] Triggering find-remote signal", self.entry_id)
-        await self.hass.async_add_executor_job(self._proxy.find_remote)
+        await self.hass.async_add_executor_job(self._proxy.find_remote, self.version)
 
     def _async_update_options(self, key: str, value: Any) -> None:
         """Update a key in the ConfigEntry options."""

--- a/custom_components/sofabaton_x1s/lib/protocol_const.py
+++ b/custom_components/sofabaton_x1s/lib/protocol_const.py
@@ -57,6 +57,7 @@ OP_REQ_BUTTONS = 0x023C  # payload: [act_lo, 0xFF]
 OP_REQ_COMMANDS = 0x025C  # payload: [dev_lo, cmd] (1-byte) or [dev_lo, 0xFF] for full list
 OP_REQ_ACTIVATE = 0x023F  # payload: [id_lo, key_code] (activity or device ID)
 OP_FIND_REMOTE = 0x0023  # payload: [0x01] to trigger remote buzzer
+OP_FIND_REMOTE_X2 = 0x0323  # payload: [0x00, 0x00, 0x08] observed on X2 hubs
 OP_CREATE_DEVICE_HEAD = 0x07D5  # payload includes UTF-16LE device name
 OP_DEFINE_IP_CMD = 0x0ED3  # payload includes HTTP method/URL/headers
 OP_DEFINE_IP_CMD_EXISTING = 0x0EAE  # payload defines IP command for an existing device
@@ -130,6 +131,7 @@ OPNAMES: Dict[int, str] = {
     OP_REQ_COMMANDS: "REQ_COMMANDS",
     OP_REQ_ACTIVATE: "REQ_ACTIVATE",
     OP_FIND_REMOTE: "FIND_REMOTE",
+    OP_FIND_REMOTE_X2: "FIND_REMOTE_X2",
     OP_CREATE_DEVICE_HEAD: "CREATE_DEVICE_HEAD",
     OP_DEFINE_IP_CMD: "DEFINE_IP_CMD",
     OP_DEFINE_IP_CMD_EXISTING: "DEFINE_IP_CMD_EXISTING",
@@ -234,6 +236,7 @@ __all__ = [
     "OP_REQ_COMMANDS",
     "OP_REQ_ACTIVATE",
     "OP_FIND_REMOTE",
+    "OP_FIND_REMOTE_X2",
     "OP_CREATE_DEVICE_HEAD",
     "OP_DEFINE_IP_CMD",
     "OP_DEFINE_IP_CMD_EXISTING",


### PR DESCRIPTION
## Summary
- add an X2-specific find-remote opcode and payload mapping
- retain hub version on the proxy and pass it from the hub so find-remote uses the right command
- cover the new find-remote routing with proxy unit tests

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b0ac616c4832db1a4b29917ba19bf)