### PR TITLE
Allow manual X2 setup while gating discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ Also keep in mind that as soon as a client is connected to the physical hub, the
 - Your HA instance must be able to open TCP ports (so the real hub can connect to our integration)
 - Your HA instance must be able to open UDP ports (optional; only if you want the official app to be able to connect to the hub while this integration is running)
 
+### X2 discovery (opt-in)
+
+The X2 hub advertises the same discovery records as the official SofaBaton integration. To avoid duplicate prompts, **X2 discovery is disabled by default** in this custom integration. Manual setup remains available. If you want discovery prompts for X2 hubs, add the YAML flag below and restart Home Assistant:
+
+```yaml
+sofabaton_x1s:
+  enable_x2_discovery: true
+```
+
+With the flag enabled, X2 hubs will show the normal discovery confirmation.
+
 ---
 
 ## Installation

--- a/custom_components/sofabaton_x1s/const.py
+++ b/custom_components/sofabaton_x1s/const.py
@@ -15,6 +15,7 @@ CONF_MDNS_TXT = "mdns_txt"
 CONF_MDNS_VERSION = "mdns_version"
 CONF_PROXY_ENABLED = "proxy_enabled"
 CONF_HEX_LOGGING_ENABLED = "hex_logging_enabled"
+CONF_ENABLE_X2_DISCOVERY = "enable_x2_discovery"
 
 # Hub version classification
 HVER_X1 = "1"

--- a/custom_components/sofabaton_x1s/translations/en.json
+++ b/custom_components/sofabaton_x1s/translations/en.json
@@ -26,6 +26,9 @@
         "title": "Discovered Sofabaton hub",
         "description": "Home Assistant found a Sofabaton hub ({{name}} @ {{host}}). Confirm to set it up."
       }
+    },
+    "abort": {
+      "x2_disabled": "SofaBaton X2 discovery is disabled. To enable it, add `enable_x2_discovery: true` under `sofabaton_x1s:` in configuration.yaml and restart Home Assistant."
     }
   },
   "options": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,10 @@ def _install_homeassistant_stubs() -> None:
     helpers = types.ModuleType("homeassistant.helpers")
     sys.modules.setdefault("homeassistant.helpers", helpers)
 
+    config_validation = types.ModuleType("homeassistant.helpers.config_validation")
+    config_validation.boolean = lambda value=None: value  # type: ignore[assignment]
+    sys.modules.setdefault("homeassistant.helpers.config_validation", config_validation)
+
     service_info = types.ModuleType("homeassistant.helpers.service_info")
     sys.modules.setdefault("homeassistant.helpers.service_info", service_info)
 


### PR DESCRIPTION
### Motivation

- Prevent accidental duplicate prompts by gating SofaBaton X2 only for mDNS/zeroconf discovery while keeping manual setup available.
- Rename the YAML opt-in to `enable_x2_discovery` to clarify it controls discovery behavior only.
- Ensure X2 support is explicit for zeroconf but does not block a user from manually adding an X2 hub.

### Description

- Rename the constant to `CONF_ENABLE_X2_DISCOVERY` and update references to the new key.  
- Add a `CONFIG_SCHEMA` and `async_setup` that read the YAML flag and store it at `hass.data[DOMAIN]['config'][CONF_ENABLE_X2_DISCOVERY]`.  
- Change the config flow so `async_step_zeroconf` aborts when an X2 is discovered and discovery is disabled, while the manual flow always includes `HUB_VERSION_X2` as an option.  
- Update docs and translation strings (`README.md`, `translations/en.json`) and adjust tests (`tests/test_config_flow_discovery.py`, `tests/conftest.py`) and small hub-management helpers in `__init__.py` (`_get_hubs` and related fixes). 

### Testing

- Ran the full test suite with `pytest` and it succeeded.  
- Test suite output: `90 passed`.  
- Updated `tests/test_config_flow_discovery.py` verifies that manual setup includes X2 regardless of the discovery flag and that zeroconf X2 is aborted when discovery is disabled.  
- No automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fa52bcd04832d8ec4c2168668058f)