### PR TITLE
Add delete_device action with activity confirmation replay

### DIFF
--- a/custom_components/sofabaton_x1s/__init__.py
+++ b/custom_components/sofabaton_x1s/__init__.py
@@ -233,6 +233,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.services.async_register(DOMAIN, "create_wifi_device", _async_handle_create_wifi_device)
     if not hass.services.has_service(DOMAIN, "device_to_activity"):
         hass.services.async_register(DOMAIN, "device_to_activity", _async_handle_device_to_activity)
+    if not hass.services.has_service(DOMAIN, "delete_device"):
+        hass.services.async_register(DOMAIN, "delete_device", _async_handle_delete_device)
     if not hass.services.has_service(DOMAIN, "command_to_favorite"):
         hass.services.async_register(DOMAIN, "command_to_favorite", _async_handle_command_to_favorite)
     if not hass.services.has_service(DOMAIN, "command_to_button"):
@@ -282,6 +284,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.services.async_remove(DOMAIN, "fetch_device_commands")
             hass.services.async_remove(DOMAIN, "create_wifi_device")
             hass.services.async_remove(DOMAIN, "device_to_activity")
+            hass.services.async_remove(DOMAIN, "delete_device")
             hass.services.async_remove(DOMAIN, "command_to_favorite")
             hass.services.async_remove(DOMAIN, "command_to_button")
             #hass.services.async_remove(DOMAIN, "create_ip_button")
@@ -360,6 +363,19 @@ async def _async_handle_device_to_activity(call: ServiceCall):
         activity_id=activity_id,
         device_id=device_id,
     )
+
+
+async def _async_handle_delete_device(call: ServiceCall):
+    hass = call.hass
+    hub = await _async_resolve_hub_from_call(hass, call)
+    if hub is None:
+        raise ValueError("Could not resolve Sofabaton hub from service call")
+
+    device_id = int(call.data["device_id"])
+    if device_id < 1 or device_id > 255:
+        raise ValueError("device_id must be between 1 and 255")
+
+    return await hub.async_delete_device(device_id=device_id)
 
 
 async def _async_handle_command_to_favorite(call: ServiceCall):

--- a/custom_components/sofabaton_x1s/hub.py
+++ b/custom_components/sofabaton_x1s/hub.py
@@ -468,6 +468,14 @@ class SofabatonHub:
             device_id,
         )
 
+    async def async_delete_device(self, device_id: int) -> dict[str, Any] | None:
+        """Delete a device and confirm impacted activities on the selected hub."""
+
+        return await self.hass.async_add_executor_job(
+            self._proxy.delete_device,
+            device_id,
+        )
+
     async def async_command_to_favorite(
         self,
         activity_id: int,

--- a/custom_components/sofabaton_x1s/lib/opcode_handlers.py
+++ b/custom_components/sofabaton_x1s/lib/opcode_handlers.py
@@ -782,11 +782,17 @@ class X1CatalogActivityHandler(BaseFrameHandler):
 
         act_id = int.from_bytes(payload[6:8], "big") if len(payload) >= 8 else None
         active_flag = frame.raw[35] if len(frame.raw) > 35 else 0
+        needs_confirm_flag = payload[95] if len(payload) > 95 else 0
         activity_label = payload[32:].split(b"\x00", 1)[0].decode("utf-8", errors="ignore")
         is_active = active_flag == 1
+        needs_confirm = needs_confirm_flag == 1
 
         if act_id is not None:
-            proxy.state.activities[act_id & 0xFF] = {"name": activity_label, "active": is_active}
+            proxy.state.activities[act_id & 0xFF] = {
+                "name": activity_label,
+                "active": is_active,
+                "needs_confirm": needs_confirm,
+            }
             if is_active:
                 proxy.state.set_hint(act_id)
             proxy._notify_activity_list_update()

--- a/custom_components/sofabaton_x1s/lib/protocol_const.py
+++ b/custom_components/sofabaton_x1s/lib/protocol_const.py
@@ -57,6 +57,7 @@ OP_REQ_BUTTONS = 0x023C  # payload: [act_lo, 0xFF]
 OP_REQ_COMMANDS = 0x025C  # payload: [dev_lo, cmd] (1-byte) or [dev_lo, 0xFF] for full list
 OP_REQ_ACTIVATE = 0x023F  # payload: [id_lo, key_code] (activity or device ID)
 OP_REQ_ACTIVITY_MAP = 0x016C  # payload: [act_lo] request activity favorites mapping (X1)
+OP_DELETE_DEVICE = 0x0109  # payload: [dev_lo] delete an existing device (observed X1)
 OP_FIND_REMOTE = 0x0023  # payload: [0x01] to trigger remote buzzer
 OP_FIND_REMOTE_X2 = 0x0323  # payload: [0x00, 0x00, 0x08] observed on X2 hubs
 OP_CREATE_DEVICE_HEAD = 0x07D5  # payload includes UTF-16LE device name
@@ -128,6 +129,7 @@ OP_MACROS_B2 = 0x6413
 OP_ACTIVITY_INPUTS_PAGE_A = 0xFA47  # H→A activity-input candidates page (X1S/X2)
 OP_ACTIVITY_INPUTS_PAGE_B = 0xC947  # H→A final activity-input candidates page (X1S/X2)
 OP_ACTIVITY_ASSIGN_FINALIZE = 0xD538  # A→H post-macro activity assignment save (X1S/X2)
+OP_ACTIVITY_CONFIRM = 0x7B38  # A→H activity confirmation row write (observed X1)
 OP_ACTIVITY_MAP_PAGE_X1S = 0xD56D  # H→A activity mapping page variant (X1S/X2)
 OP_BANNER = 0x1D02  # hub ident, name, batch, hub fw (first screen)
 OP_WIFI_FW = 0x0359  # WiFi firmware ver (Vx.y.z)
@@ -142,6 +144,7 @@ OPNAMES: Dict[int, str] = {
     OP_REQ_COMMANDS: "REQ_COMMANDS",
     OP_REQ_ACTIVATE: "REQ_ACTIVATE",
     OP_REQ_ACTIVITY_MAP: "REQ_ACTIVITY_MAP",
+    OP_DELETE_DEVICE: "DELETE_DEVICE",
     OP_FIND_REMOTE: "FIND_REMOTE",
     OP_FIND_REMOTE_X2: "FIND_REMOTE_X2",
     OP_CREATE_DEVICE_HEAD: "CREATE_DEVICE_HEAD",
@@ -199,6 +202,7 @@ OPNAMES: Dict[int, str] = {
     OP_ACTIVITY_INPUTS_PAGE_A: "ACTIVITY_INPUTS_PAGE_A",
     OP_ACTIVITY_INPUTS_PAGE_B: "ACTIVITY_INPUTS_PAGE_B",
     OP_ACTIVITY_ASSIGN_FINALIZE: "ACTIVITY_ASSIGN_FINALIZE",
+    OP_ACTIVITY_CONFIRM: "ACTIVITY_CONFIRM",
     OP_ACTIVITY_MAP_PAGE_X1S: "ACTIVITY_MAP_PAGE_X1S",
     OP_REQ_VERSION: "REQ_VERSION",
     OP_PING2: "PING2",
@@ -256,6 +260,7 @@ __all__ = [
     "OP_REQ_COMMANDS",
     "OP_REQ_ACTIVATE",
     "OP_REQ_ACTIVITY_MAP",
+    "OP_DELETE_DEVICE",
     "OP_FIND_REMOTE",
     "OP_FIND_REMOTE_X2",
     "OP_CREATE_DEVICE_HEAD",
@@ -312,6 +317,7 @@ __all__ = [
     "OP_ACTIVITY_INPUTS_PAGE_A",
     "OP_ACTIVITY_INPUTS_PAGE_B",
     "OP_ACTIVITY_ASSIGN_FINALIZE",
+    "OP_ACTIVITY_CONFIRM",
     "OP_ACTIVITY_MAP_PAGE_X1S",
     "OP_BANNER",
     "OP_WIFI_FW",

--- a/custom_components/sofabaton_x1s/services.yaml
+++ b/custom_components/sofabaton_x1s/services.yaml
@@ -136,6 +136,25 @@ device_to_activity:
           max: 99
           mode: box
 
+delete_device:
+  name: Delete device
+  description: Deletes a device and confirms all impacted activities on the selected hub.
+  fields:
+    device:
+      name: Sofabaton hub
+      required: true
+      selector:
+        device:
+          integration: sofabaton_x1s
+    device_id:
+      name: Device id
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 255
+          mode: box
+
 command_to_favorite:
   name: Add command to activity favorite
   description: Makes a favorite from a command on the selected hub.

--- a/tests/test_opcode_handlers.py
+++ b/tests/test_opcode_handlers.py
@@ -730,7 +730,7 @@ def test_x1_activity_row_updates_state_and_hint() -> None:
 
     handler.handle(frame)
 
-    assert proxy.state.activities[0x65] == {"name": "Jellyfin", "active": False}
+    assert proxy.state.activities[0x65] == {"name": "Jellyfin", "active": False, "needs_confirm": False}
     assert proxy.state.current_activity_hint is None
     assert proxy._burst.kind == "activities"
 
@@ -750,8 +750,26 @@ def test_x1_activity_active_flag_uses_correct_offset() -> None:
 
     handler.handle(frame)
 
-    assert proxy.state.activities[0x66] == {"name": "Room Control", "active": True}
+    assert proxy.state.activities[0x66] == {"name": "Room Control", "active": True, "needs_confirm": False}
     assert proxy.state.current_activity_hint == 0x66
+
+
+def test_x1_activity_row_sets_needs_confirm_flag() -> None:
+    proxy = X1Proxy(
+        "127.0.0.1", proxy_udp_port=0, proxy_enabled=False, diag_dump=False, diag_parse=False
+    )
+    handler = X1CatalogActivityHandler()
+
+    frame = _build_context(
+        proxy,
+        "a5 5a 7b 3b 02 00 01 02 00 01 00 66 01 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 68 65 79 6f 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fc 00 fc 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 9a 6c",
+        OP_X1_ACTIVITY,
+        "X1_ACTIVITY",
+    )
+
+    handler.handle(frame)
+
+    assert proxy.state.activities[0x66] == {"name": "heyo", "active": False, "needs_confirm": True}
 
 
 def test_catalog_activity_handler_decodes_utf16_labels() -> None:


### PR DESCRIPTION
### Motivation
- Implement a full "delete device" flow that mirrors existing action patterns (e.g. `device_to_activity`) by performing the device delete, scanning `REQ_ACTIVITIES`, and replaying per-activity confirmation rows when required.
- Ensure the hub/proxy service-level API and Home Assistant service plumbing expose the action safely with input validation and an async wrapper.

### Description
- Add protocol constants and readable names for the observed opcodes: `OP_DELETE_DEVICE (0x0109)` and `OP_ACTIVITY_CONFIRM (0x7B38)` in `protocol_const.py` so ACK/dump logic can refer to them semantically.
- Parse and persist the activity confirmation/warning flag from X1 `OP_X1_ACTIVITY` rows into `X1Proxy` state as `needs_confirm`, by reading the payload flag and storing `"needs_confirm"` on activity rows in the X1 activity handler.
- Implement `X1Proxy.delete_device(device_id)` which: starts the Roku-create transaction, sends the delete-device family write (family `0x09`) and waits for the `0x0103` ACK, requests activities and waits for the completed activities burst, identifies activities with `needs_confirm`, sends an `OP_ACTIVITY_CONFIRM` row per impacted activity and waits for ACKs, clears related caches, removes the device from internal state, and returns a structured status dict.
- Expose the action through the integration surface by adding `async_delete_device` in `hub.py`, registering `_async_handle_delete_device` as the `delete_device` service in `__init__.py`, adding schema to `services.yaml`, and validating `device_id` in the service handler.
- Add unit tests and small handler updates: tests for `delete_device` proxy flow and ACK handling in `tests/test_x1_proxy.py`, a test for parsing the `needs_confirm` flag in `tests/test_opcode_handlers.py`, and service handler validation/tests in `tests/test_roku_service_validation.py`.

### Testing
- Ran the relevant test suite with `pytest -q tests/test_protocol_consts.py tests/test_opcode_handlers.py tests/test_x1_proxy.py tests/test_roku_service_validation.py` and all tests passed locally with `85 passed`.
- The new tests cover: the proxy delete + activity-confirm replay path, delete ACK failure handling, activity row `needs_confirm` parsing, and service input validation, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b7a974048832db701785e689967a1)