### PR TITLE
feat: programmatic device/activity creation via native hub protocol

### DIFF
--- a/custom_components/sofabaton_x1s/__init__.py
+++ b/custom_components/sofabaton_x1s/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
 import logging
 from pathlib import Path
@@ -2011,8 +2012,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.services.async_register(DOMAIN, "command_to_button", _async_handle_command_to_button)
     if not hass.services.has_service(DOMAIN, "sync_command_config"):
         hass.services.async_register(DOMAIN, "sync_command_config", _async_handle_sync_command_config)
-    #if not hass.services.has_service(DOMAIN, "create_ip_button"):
-    #    hass.services.async_register(DOMAIN, "create_ip_button", _async_handle_create_ip_button)
+    if not hass.services.has_service(DOMAIN, "create_ip_button"):
+        hass.services.async_register(DOMAIN, "create_ip_button", _async_handle_create_ip_button)
+    if not hass.services.has_service(DOMAIN, "create_activity"):
+        hass.services.async_register(DOMAIN, "create_activity", _async_handle_create_activity)
+    if not hass.services.has_service(DOMAIN, "delete_activity"):
+        hass.services.async_register(DOMAIN, "delete_activity", _async_handle_delete_activity)
+    if not hass.services.has_service(DOMAIN, "disable_device_power_control"):
+        hass.services.async_register(DOMAIN, "disable_device_power_control", _async_handle_disable_device_power_control)
 
     hass.data[DOMAIN][entry.entry_id] = hub
 
@@ -2070,7 +2077,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.services.async_remove(DOMAIN, "delete_favorite")
             hass.services.async_remove(DOMAIN, "command_to_button")
             hass.services.async_remove(DOMAIN, "sync_command_config")
-            #hass.services.async_remove(DOMAIN, "create_ip_button")
+            hass.services.async_remove(DOMAIN, "create_ip_button")
+            hass.services.async_remove(DOMAIN, "create_activity")
+            hass.services.async_remove(DOMAIN, "delete_activity")
+            hass.services.async_remove(DOMAIN, "disable_device_power_control")
             async_teardown_diagnostics(hass)
             if _get_lovelace_resource_mode(hass) == _LOVELACE_STORAGE_MODE:
                 if hass.data[DOMAIN].get("storage_resources_registered"):
@@ -2582,11 +2592,13 @@ async def _async_handle_create_ip_button(call: ServiceCall):
         raise ValueError("Could not resolve Sofabaton hub from service call")
 
     device_id = call.data.get("device_id")
-    device_name = call.data["device_name"].strip()
+    device_name = str(call.data.get("device_name", "")).strip()
     button_name = call.data["button_name"].strip()
     method = call.data.get("method", "GET").upper()
     url = call.data["url"]
     headers = {str(k): str(v) for k, v in (call.data.get("headers") or {}).items()}
+    body = str(call.data.get("body", ""))
+    icon = int(call.data.get("icon", 1))
 
     parsed = urlparse(url)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
@@ -2600,25 +2612,87 @@ async def _async_handle_create_ip_button(call: ServiceCall):
         raise ValueError("headers must be a mapping")
 
     if device_id is not None:
+        key_index = int(call.data.get("key_index", 1))
         result = await hass.async_add_executor_job(
-            hub._proxy.add_ip_button_to_device,
-            int(device_id),
-            button_name,
-            method,
-            url,
-            headers,
+            functools.partial(
+                hub._proxy.add_ip_button_to_device,
+                device_id=int(device_id),
+                button_name=button_name,
+                method=method,
+                url=url,
+                headers=headers,
+                key_index=key_index,
+                device_name=device_name or None,
+                body=body,
+                icon=icon,
+            ),
         )
     else:
+        if not device_name:
+            raise ValueError("device_name is required when creating a new device")
         result = await hass.async_add_executor_job(
-            hub._proxy.create_ip_button,
-            device_name,
-            button_name,
-            method,
-            url,
-            headers,
+            functools.partial(
+                hub._proxy.create_ip_button,
+                device_name=device_name,
+                button_name=button_name,
+                method=method,
+                url=url,
+                headers=headers,
+                body=body,
+                icon=icon,
+            ),
         )
 
     return result or {}
+
+
+async def _async_handle_create_activity(call: ServiceCall):
+    hass = call.hass
+    hub = await _async_resolve_hub_from_call(hass, call)
+    if hub is None:
+        raise ValueError("Could not resolve Sofabaton hub from service call")
+
+    activity_name = call.data["activity_name"].strip()
+    member_device_ids = [int(d) for d in call.data.get("member_device_ids", [])]
+    power_on_steps = call.data.get("power_on_steps") or None
+    power_off_steps = call.data.get("power_off_steps") or None
+    icon = int(call.data.get("icon", 1))
+    color_id = int(call.data.get("color_id", 0))
+
+    result = await hass.async_add_executor_job(
+        functools.partial(
+            hub._proxy.create_activity,
+            activity_name=activity_name,
+            member_device_ids=member_device_ids,
+            power_on_steps=power_on_steps,
+            power_off_steps=power_off_steps,
+            icon=icon,
+            color_id=color_id,
+        ),
+    )
+    return result or {}
+
+
+async def _async_handle_delete_activity(call: ServiceCall):
+    hass = call.hass
+    hub = await _async_resolve_hub_from_call(hass, call)
+    if hub is None:
+        raise ValueError("Could not resolve Sofabaton hub from service call")
+
+    activity_id = int(call.data["activity_id"])
+    result = await hass.async_add_executor_job(hub._proxy.delete_activity, activity_id)
+    return {"ok": bool(result)}
+
+
+async def _async_handle_disable_device_power_control(call: ServiceCall):
+    hass = call.hass
+    hub = await _async_resolve_hub_from_call(hass, call)
+    if hub is None:
+        raise ValueError("Could not resolve Sofabaton hub from service call")
+
+    device_id = int(call.data["device_id"])
+    result = await hass.async_add_executor_job(hub._proxy.disable_device_power_control, device_id)
+    return {"ok": bool(result)}
 
 async def _async_resolve_hub_from_call(hass: HomeAssistant, call: ServiceCall):
     return await _async_resolve_hub_from_data(hass, call.data)

--- a/custom_components/sofabaton_x1s/lib/protocol_const.py
+++ b/custom_components/sofabaton_x1s/lib/protocol_const.py
@@ -97,6 +97,21 @@ OP_CREATE_DEVICE_HEAD = 0x07D5  # payload includes UTF-16LE device name
 OP_DEFINE_IP_CMD = 0x0ED3  # payload includes HTTP method/URL/headers
 OP_DEFINE_IP_CMD_EXISTING = 0x0EAE  # payload defines IP command for an existing device
 OP_PREPARE_SAVE = 0x4102  # payload triggers save transaction start
+
+# Native hub protocol families (single-byte command byte embedded in frame)
+# -------------------------------------------------------------------------
+# These are low-level frame families used by the hub's native (non-virtual-device)
+# protocol path. Each family byte is the CMD field in the A5 5A frame.
+# Frames use the format: [A5][5A][LEN][CMD][data...][CHECKSUM]
+NATIVE_CMD_CREATE_DEVICE = 0x07   # CMD=7:  create a new device (X1S/X2: 210-byte data)
+NATIVE_CMD_COMMIT_DEVICE = 0x08   # CMD=8:  commit/save device config
+NATIVE_CMD_SYNC_KEY = 0x0E        # CMD=14: sync a key/command to a device
+NATIVE_CMD_CREATE_ACTIVITY = 0x37 # CMD=55: create an activity
+NATIVE_CMD_DELETE_ACTIVITY = 0x39 # CMD=57: delete an activity
+NATIVE_CMD_SAVE_MACRO = 0x12      # CMD=18: save power-on/off macros for an activity
+NATIVE_CMD_POWER_MODE_QUERY = 0x40  # CMD=64: query device power mode
+NATIVE_CMD_POWER_MODE_SET = 0x41    # CMD=65: set device power mode (powerMode field)
+NATIVE_ACK_POWER_MODE = 0x42        # CMD=66: hub reply to power mode query
 OP_FINALIZE_DEVICE = 0x4677
 OP_DEVICE_SAVE_HEAD = 0x8D5D  # hub assigns device id
 OP_SAVE_COMMIT = 0x6501
@@ -539,6 +554,15 @@ __all__ = [
     "OP_FINALIZE_DEVICE",
     "OP_DEVICE_SAVE_HEAD",
     "OP_SAVE_COMMIT",
+    "NATIVE_CMD_CREATE_DEVICE",
+    "NATIVE_CMD_COMMIT_DEVICE",
+    "NATIVE_CMD_SYNC_KEY",
+    "NATIVE_CMD_CREATE_ACTIVITY",
+    "NATIVE_CMD_DELETE_ACTIVITY",
+    "NATIVE_CMD_SAVE_MACRO",
+    "NATIVE_CMD_POWER_MODE_QUERY",
+    "NATIVE_CMD_POWER_MODE_SET",
+    "NATIVE_ACK_POWER_MODE",
     "ACK_SUCCESS",
     "OP_STATUS_ACK",
     "OP_REQ_IPCMD_SYNC",

--- a/custom_components/sofabaton_x1s/lib/proxy_activity_ops.py
+++ b/custom_components/sofabaton_x1s/lib/proxy_activity_ops.py
@@ -24,13 +24,23 @@ from .protocol_const import (
     ButtonName,
     FAMILY_FAV_DELETE,
     FAMILY_FAV_ORDER_REQ,
+    NATIVE_CMD_CREATE_ACTIVITY,
+    NATIVE_CMD_DELETE_ACTIVITY,
+    NATIVE_CMD_SAVE_MACRO,
     OP_ACTIVITY_ASSIGN_FINALIZE,
     OP_ACTIVITY_CONFIRM,
     OP_ACTIVITY_DEVICE_CONFIRM,
+    OP_REMOTE_SYNC,
     OP_REQ_MACRO_LABELS,
+    SYNC0,
+    SYNC1,
 )
 
 log = logging.getLogger("x1proxy")
+
+
+def _sum8(b: bytes | bytearray) -> int:
+    return sum(b) & 0xFF
 
 
 # Position of the tail token block inside a CATALOG_ROW_ACTIVITY payload.
@@ -935,6 +945,251 @@ class ActivityOpsMixin:
             result["long_press_device_id"] = long_press_device_id & 0xFF
             result["long_press_command_id"] = long_press_command_id & 0xFF
         return result
+
+    # ------------------------------------------------------------------
+    # Native activity creation (CMD=55 / CMD=18)
+    # ------------------------------------------------------------------
+
+    def _build_activity_data_x2(
+        self,
+        name: str,
+        *,
+        icon: int = 1,
+        activity_id: int = 0xFF,
+        color_id: int = 0,
+    ) -> bytes:
+        """Build the 210-byte X1S/X2 activity payload for CMD=55 (create activity)."""
+        d = bytearray(210)
+        d[0] = 0x01
+        d[1:3] = (1).to_bytes(2, "big")
+        d[3] = 0   # sign
+        d[4] = activity_id & 0xFF
+        d[5] = icon & 0xFF
+        d[6] = 0   # sort
+        # name and brand slots (UTF-16BE, 60 bytes each at offsets 29 and 89)
+        name_enc = name.encode("utf-16-be")
+        name_slot = (name_enc[:60] + b"\x00" * 60)[:60]
+        d[29:89] = name_slot
+        d[89:149] = name_slot   # brand = name
+
+        cfg = bytearray(60)
+        cfg[0] = 0xFC
+        cfg[1] = 0x00
+        cfg[2] = 0xFC
+        cfg[3] = 0x00
+        cfg[22] = color_id & 0xFF
+        d[149:209] = cfg
+        d[209] = _sum8(d[:209])
+        return bytes(d)
+
+    def _build_macro_frames_x2(
+        self,
+        activity_id: int,
+        key_id: int,
+        steps: list[tuple],
+        macro_name: str = "",
+    ) -> list[bytes]:
+        """Build CMD=18 macro save frames for an activity's power-on or power-off key.
+
+        ``key_id`` is 198 for power-on and 199 for power-off (hub convention).
+
+        ``steps`` is a list of tuples:
+          ``("cmd", device_id, key_id)`` — fire a button on a device
+          ``("delay", seconds)``         — insert a delay
+        """
+        step_count = len(steps)
+        step_data = bytearray()
+        for step in steps:
+            if step[0] == "delay":
+                sd = bytearray(10)
+                for i in range(9):
+                    sd[i] = 0xFF
+                sd[9] = step[1] & 0xFF
+                step_data += sd
+            else:
+                # ("cmd", device_id, key_id)
+                sd = bytearray(10)
+                sd[0] = step[1] & 0xFF  # device_id
+                sd[1] = step[2] & 0xFF  # key_id (198=power_on, 199=power_off)
+                sd[8] = 1               # duration
+                sd[9] = 0xFF
+                step_data += sd
+
+        # name slot (UTF-16BE, 60 bytes)
+        name_enc = macro_name.encode("utf-16-be")
+        name_bytes = (name_enc[:60] + b"\x00" * 60)[:60]
+
+        inner_len = len(step_data) + 6 + 60 + 1  # header(6) + name(60) + checksum(1)
+        inner = bytearray(inner_len)
+        total_pages = (inner_len + 246) // 247
+        inner[0] = 0x01
+        inner[1:3] = total_pages.to_bytes(2, "big")
+        inner[3] = activity_id & 0xFF
+        inner[4] = key_id & 0xFF
+        inner[5] = step_count & 0xFF
+        inner[6 : 6 + len(step_data)] = step_data
+        inner[6 + len(step_data) : 6 + len(step_data) + 60] = name_bytes
+        inner[-1] = _sum8(inner[:-1])
+
+        frames = []
+        for page_idx in range(total_pages):
+            offset = page_idx * 247
+            end = min(offset + 247, inner_len)
+            chunk = inner[offset:end]
+            chunk_len = len(chunk)
+            f = bytearray(chunk_len + 8)
+            f[0] = SYNC0
+            f[1] = SYNC1
+            f[2] = (chunk_len + 3) & 0xFF
+            f[3] = NATIVE_CMD_SAVE_MACRO
+            f[4] = 0x01
+            f[5:7] = (page_idx + 1).to_bytes(2, "big")
+            f[7 : 7 + chunk_len] = chunk
+            f[-1] = _sum8(f[:-1])
+            frames.append(bytes(f))
+        return frames
+
+    def create_activity(
+        self,
+        *,
+        activity_name: str,
+        member_device_ids: list[int],
+        power_on_steps: list[tuple] | None = None,
+        power_off_steps: list[tuple] | None = None,
+        icon: int = 1,
+        color_id: int = 0,
+    ) -> dict[str, Any] | None:
+        """Create a new activity on the hub with optional power macros.
+
+        ``member_device_ids`` lists the device IDs to include in the activity.
+        The hub assigns the activity ID automatically via its CMD=55 ACK.
+
+        ``power_on_steps`` / ``power_off_steps`` are lists of tuples for the
+        CMD=18 macro (keys 198 / 199):
+          ``("cmd", device_id, key_index)`` — fire a button
+          ``("delay", seconds)``            — pause
+        If ``None``, the corresponding macro is skipped entirely.
+        """
+        if not self.can_issue_commands():
+            self._log.info("[ACTIVITY] create_activity ignored: proxy client is connected")
+            return None
+
+        overhead = b"\x01" + (1).to_bytes(2, "big")
+
+        # CMD=55: create activity
+        create_data = self._build_activity_data_x2(
+            activity_name, icon=icon, activity_id=0xFF, color_id=color_id,
+        )
+
+        # Reuse the _build_native_frame helper defined in WifiDeviceMixin
+        create_frame = self._build_native_frame(NATIVE_CMD_CREATE_ACTIVITY, overhead, create_data)
+
+        self.reset_ack_queues()
+        self._log.info("[ACTIVITY] sending CMD=55 (create) for '%s'", activity_name)
+        self.transport.send_local(create_frame)
+
+        activity_id = self.wait_for_assigned_device_id(timeout=5.0)
+        if activity_id is None:
+            self._log.warning("[ACTIVITY] hub did not assign activity_id after CMD=55")
+            return None
+        self._log.info("[ACTIVITY] hub assigned activity_id=%d", activity_id)
+
+        # CMD=18: POWER_ON macro (key 198)
+        if power_on_steps:
+            on_frames = self._build_macro_frames_x2(
+                activity_id, 198, power_on_steps, macro_name="Power On",
+            )
+            time.sleep(1)
+            self._log.info(
+                "[ACTIVITY] sending CMD=18 POWER_ON macro (%d steps)", len(power_on_steps),
+            )
+            for frame in on_frames:
+                self.transport.send_local(frame)
+
+        # CMD=18: POWER_OFF macro (key 199)
+        if power_off_steps:
+            off_frames = self._build_macro_frames_x2(
+                activity_id, 199, power_off_steps, macro_name="Power Off",
+            )
+            time.sleep(1)
+            self._log.info(
+                "[ACTIVITY] sending CMD=18 POWER_OFF macro (%d steps)", len(power_off_steps),
+            )
+            for frame in off_frames:
+                self.transport.send_local(frame)
+
+        # Assign member devices via OP_ACTIVITY_DEVICE_CONFIRM
+        if member_device_ids:
+            act_lo = activity_id & 0xFF
+            time.sleep(2)
+
+            self._activity_map_complete.discard(act_lo)
+            self.state.activity_members.pop(act_lo, None)
+            self.state.activity_command_refs.pop(act_lo, None)
+            self.state.activity_favorite_slots.pop(act_lo, None)
+            self.state.activity_keybinding_slots.pop(act_lo, None)
+            self.state.activity_favorite_labels.pop(act_lo, None)
+            self.state.activity_keybinding_labels.pop(act_lo, None)
+            self._clear_favorite_label_requests_for_activity(act_lo)
+
+            self._log.info(
+                "[ACTIVITY] requesting activity mapping for act=0x%02X", act_lo,
+            )
+            if self.request_activity_mapping(act_lo):
+                self._wait_for_activity_map_burst(act_lo, timeout=5.0)
+
+            self._log.info(
+                "[ACTIVITY] assigning %d member devices to activity %d: %s",
+                len(member_device_ids), activity_id, member_device_ids,
+            )
+            self.reset_ack_queues()
+            for member_id in member_device_ids:
+                payload = bytes([member_id & 0xFF, 0x00])
+                self._log.info(
+                    "[ACTIVITY] confirm member dev=0x%02X for act=0x%02X",
+                    member_id & 0xFF, act_lo,
+                )
+                self._send_cmd_frame(OP_ACTIVITY_DEVICE_CONFIRM, payload)
+                ack = self.wait_for_ack_any([(0x0103, None)], timeout=5.0)
+                if ack is None:
+                    self._log.warning(
+                        "[ACTIVITY] missing ACK after member confirm dev=0x%02X",
+                        member_id & 0xFF,
+                    )
+
+        # REMOTE_SYNC
+        sync_frame = self._build_frame(OP_REMOTE_SYNC, b"")
+        time.sleep(1)
+        self._log.info("[ACTIVITY] sending REMOTE_SYNC")
+        self.transport.send_local(sync_frame)
+
+        time.sleep(1)
+        self._log.info(
+            "[ACTIVITY] created activity '%s' id=%d members=%s",
+            activity_name, activity_id, member_device_ids,
+        )
+        return {
+            "activity_name": activity_name,
+            "activity_id": activity_id,
+            "members": member_device_ids,
+            "status": "success",
+        }
+
+    def delete_activity(self, activity_id: int) -> bool:
+        """Delete an activity from the hub using CMD=57."""
+        if not self.can_issue_commands():
+            self._log.info("[ACTIVITY] delete_activity ignored: proxy client is connected")
+            return False
+
+        act_lo = activity_id & 0xFF
+        self.reset_ack_queues()
+        return self._send_native_step(
+            step_name=f"delete-activity[act=0x{act_lo:02X}]",
+            family=NATIVE_CMD_DELETE_ACTIVITY,
+            payload=bytes([act_lo]),
+            ack_opcode=0x0103,
+            timeout=10.0,
+        )
 
 
 __all__ = ["ActivityOpsMixin"]

--- a/custom_components/sofabaton_x1s/lib/proxy_wifi_device.py
+++ b/custom_components/sofabaton_x1s/lib/proxy_wifi_device.py
@@ -31,20 +31,31 @@ from .protocol_const import (
     ButtonName,
     DEVICE_CLASS_WIFI_IP,
     DEVICE_CLASS_WIFI_ROKU,
+    NATIVE_CMD_COMMIT_DEVICE,
+    NATIVE_CMD_CREATE_DEVICE,
+    NATIVE_CMD_POWER_MODE_SET,
+    NATIVE_CMD_SYNC_KEY,
     OP_CREATE_DEVICE_HEAD,
     OP_DEFINE_IP_CMD,
     OP_DEFINE_IP_CMD_EXISTING,
     OP_FINALIZE_DEVICE,
     OP_PREPARE_SAVE,
+    OP_REMOTE_SYNC,
     OP_REQ_ACTIVITY_INPUTS,
     OP_REQ_BLOB,
     OP_SAVE_COMMIT,
+    SYNC0,
+    SYNC1,
 )
 from .state_helpers import normalize_device_entry
 
 
 def _hex_to_bytes(raw_hex: str) -> bytes:
     return bytes.fromhex(raw_hex)
+
+
+def _sum8(b: bytes | bytearray) -> int:
+    return sum(b) & 0xFF
 
 
 def _validate_wifi_input_ids(
@@ -1150,6 +1161,178 @@ class WifiDeviceMixin:
         payload.extend(self._encode_http_request(method, url, headers))
         return OP_DEFINE_IP_CMD_EXISTING, bytes(payload)
 
+    # ------------------------------------------------------------------
+    # Native frame builders (X1S/X2 hub protocol)
+    # ------------------------------------------------------------------
+    # The following helpers build raw frames for the hub's native binary
+    # protocol (A5 5A frames) used by CMD=7 (create device), CMD=14
+    # (sync key), and CMD=8 (commit device).  This path is faster and
+    # more reliable than the virtual-device/Roku replay path because it
+    # does not require the hub to be in an idle "create" state.
+    # ------------------------------------------------------------------
+
+    def _utf16be_padded(self, text: str, *, length: int) -> bytes:
+        """Encode ``text`` as UTF-16BE, truncated/zero-padded to ``length`` bytes."""
+        data = text.encode("utf-16-be")
+        truncated = data[:length]
+        return truncated + b"\x00" * max(0, length - len(truncated))
+
+    def _build_native_frame(self, cmd: int, overhead: bytes, data: bytes) -> bytes:
+        """Wrap ``overhead + data`` in an A5 5A native frame for ``cmd``."""
+        payload = overhead + data
+        frame = bytearray([SYNC0, SYNC1, len(payload) & 0xFF, cmd & 0xFF])
+        frame.extend(payload)
+        frame.append(_sum8(frame))
+        return bytes(frame)
+
+    def _build_device_data_x2(
+        self,
+        name: str,
+        *,
+        icon: int = 1,
+        device_id: int = 0xFF,
+        sign: int = 0,
+        commit: bool = False,
+        target_ip: str = "",
+    ) -> bytes:
+        """Build the 210-byte X1S/X2 device payload for CMD=7 (create) or CMD=8 (commit).
+
+        For CMD=7 pass ``device_id=0xFF`` — the hub assigns a new ID.
+        For CMD=8 pass the hub-assigned ``device_id``.
+        ``powerModel=1`` (``cfg[11]``) tells the app that power settings
+        have been configured, preventing the "Not configured" warning.
+        """
+        d = bytearray(210)
+        d[0] = 0x01
+        d[1:3] = (1).to_bytes(2, "big")
+        d[3] = sign & 0xFF
+        d[4] = device_id & 0xFF
+        d[5] = icon & 0xFF
+        d[6] = (device_id & 0xFF) if commit else 0x00
+        d[7] = 28   # codeType: WiFi DIY
+        d[8] = 16   # type: WiFi
+        d[29:89] = self._utf16be_padded(name, length=60)
+        d[89:149] = self._utf16be_padded(name, length=60)  # brand = name
+
+        cfg = bytearray(60)
+        if target_ip:
+            cfg[0] = 0xFC
+            cfg[1] = 0x55
+            for i, octet in enumerate(target_ip.split(".")[:4]):
+                cfg[2 + i] = int(octet) & 0xFF
+        cfg[6] = 0xFC
+        cfg[9] = 0xFC
+        cfg[10] = 0x02  # inputModel: WiFi
+        cfg[11] = 0x01  # powerModel=1: power settings present (prevents "Not configured")
+        cfg[14] = 0xFC
+        cfg[16] = 0xFC
+        if commit:
+            cfg[17] = 0x01
+        d[149:209] = cfg
+        d[209] = _sum8(d[:209])
+        return bytes(d)
+
+    def _build_key_frame_x2(
+        self,
+        *,
+        key_index: int,
+        total_keys: int,
+        device_id: int,
+        key_id: int,
+        key_name: str,
+        ip: str,
+        port: int,
+        pulse: str,
+    ) -> bytes:
+        """Build CMD=14 key-sync frame(s) in X1S/X2 format (81-byte overhead).
+
+        Returns all pages concatenated as a single bytes object.
+        ``key_index`` and ``key_id`` are 1-based; the caller must supply
+        them correctly (1 for the first button, 2 for the second, etc.).
+        """
+        pulse_bytes = pulse.encode("ascii", errors="replace")
+        pulse_len = len(pulse_bytes)
+
+        ip_block = bytearray(pulse_len + 8)
+        for i, p in enumerate(ip.split(".")[:4]):
+            ip_block[i] = int(p) & 0xFF
+        ip_block[4:6] = port.to_bytes(2, "big")
+        ip_block[6:8] = pulse_len.to_bytes(2, "big")
+        ip_block[8 : 8 + pulse_len] = pulse_bytes
+
+        key_data_len = pulse_len + 81
+        total_pages = (key_data_len + 246) // 247
+
+        kd = bytearray(key_data_len)
+        kd[0] = total_keys & 0xFF
+        kd[1:3] = total_pages.to_bytes(2, "big")
+        kd[3] = device_id & 0xFF
+        kd[4] = key_id & 0xFF
+        kd[5] = 0x1C   # codeType: WiFi DIY
+        kd[12:72] = self._utf16be_padded(key_name, length=60)
+        kd[72 : 72 + len(ip_block)] = ip_block
+        kd[key_data_len - 1] = _sum8(kd[: key_data_len - 1])
+
+        all_frames = bytearray()
+        for page_idx in range(total_pages):
+            offset = page_idx * 247
+            end = min(offset + 247, key_data_len)
+            chunk = kd[offset:end]
+            f = bytearray()
+            f.extend([SYNC0, SYNC1, (len(chunk) + 3) & 0xFF, NATIVE_CMD_SYNC_KEY])
+            f.append((key_index + 1) & 0xFF)
+            f.extend((page_idx + 1).to_bytes(2, "big"))
+            f.extend(chunk)
+            f.append(_sum8(f))
+            all_frames.extend(f)
+        return bytes(all_frames)
+
+    def _build_ip_pulse(
+        self,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        body: str = "",
+    ) -> str:
+        """Build the raw HTTP request string the hub sends when a key is pressed."""
+        from urllib.parse import urlparse  # noqa: PLC0415
+
+        parsed = urlparse(url)
+        host = parsed.hostname or "127.0.0.1"
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        path = parsed.path or "/"
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+
+        parts = [f"{method} {path} HTTP/1.1\r\n", f"Host:{host}:{port}\r\n"]
+        for k, v in headers.items():
+            parts.append(f"{k}:{v}\r\n")
+        if body:
+            parts.append(f"Content-Length:{len(body.encode('ascii', errors='replace'))}\r\n")
+        parts.append("\r\n")
+        if body:
+            parts.append(body)
+        return "".join(parts)
+
+    @staticmethod
+    def _extract_host(url: str) -> str:
+        from urllib.parse import urlparse  # noqa: PLC0415
+
+        return urlparse(url).hostname or "127.0.0.1"
+
+    @staticmethod
+    def _extract_port(url: str) -> int:
+        from urllib.parse import urlparse  # noqa: PLC0415
+
+        parsed = urlparse(url)
+        if parsed.port:
+            return parsed.port
+        return 443 if parsed.scheme == "https" else 80
+
+    # ------------------------------------------------------------------
+    # Native IP device creation
+    # ------------------------------------------------------------------
+
     def create_ip_button(
         self,
         *,
@@ -1158,41 +1341,90 @@ class WifiDeviceMixin:
         method: str,
         url: str,
         headers: dict[str, str],
+        body: str = "",
+        icon: int = 1,
     ) -> dict[str, Any] | None:
+        """Create a new IP device on the hub with one button.
+
+        Uses the hub's native protocol: CMD=7 (create), CMD=14 (key sync),
+        CMD=8 (commit), then REMOTE_SYNC.  Each frame is sent individually
+        with a delay so the hub can process them one at a time.
+
+        The caller should follow up with :meth:`disable_device_power_control`
+        to set ``powerMode=4`` (no automatic power control) after creation.
+        """
         if not self.can_issue_commands():
             self._log.info("[CREATE] create_ip_button ignored: proxy client is connected")
             return None
 
-        frames = self._build_virtual_device_frames(
-            device_name=device_name,
-            button_name=button_name,
-            method=method,
-            url=url,
-            headers=headers,
+        overhead = b"\x01" + (1).to_bytes(2, "big")  # action=1, count=1
+
+        # CMD=7: create device
+        target_ip = self._extract_host(url)
+        create_data = self._build_device_data_x2(
+            device_name, device_id=0xFF, target_ip=target_ip, icon=icon,
+        )
+        create_frame = self._build_native_frame(NATIVE_CMD_CREATE_DEVICE, overhead, create_data)
+
+        self.reset_ack_queues()
+        self._log.info("[CREATE] sending CMD=7 (create) for '%s'", device_name)
+        self.transport.send_local(create_frame)
+
+        device_id = self.wait_for_assigned_device_id(timeout=3.0)
+        if device_id is None:
+            self._log.warning("[CREATE] hub did not assign device_id after CMD=7")
+            return None
+        self._log.info("[CREATE] hub assigned device_id=%d", device_id)
+
+        # CMD=14: key sync — hub uses 1-based button slots
+        pulse = self._build_ip_pulse(method, url, headers, body=body)
+        key_frame = self._build_key_frame_x2(
+            key_index=1,
+            total_keys=1,
+            device_id=device_id,
+            key_id=1,
+            key_name=button_name,
+            ip=self._extract_host(url),
+            port=self._extract_port(url),
+            pulse=pulse,
         )
 
-        self.start_virtual_device(
-            device_name=device_name,
-            button_name=button_name,
-            method=method,
-            url=url,
-            headers=headers,
+        time.sleep(1)
+        self._log.info("[CREATE] sending CMD=14 (key sync) for '%s'", button_name)
+        self.transport.send_local(key_frame)
+
+        # CMD=8: commit
+        commit_data = self._build_device_data_x2(
+            device_name, device_id=device_id, commit=True,
+            target_ip=target_ip, icon=icon,
         )
+        commit_frame = self._build_native_frame(NATIVE_CMD_COMMIT_DEVICE, overhead, commit_data)
 
-        for opcode, payload in frames:
-            self._send_cmd_frame(opcode, payload)
-            time.sleep(0.05)
+        time.sleep(1)
+        self._log.info("[CREATE] sending CMD=8 (commit) dev=%d", device_id)
+        self.transport.send_local(commit_frame)
 
-        result = self.wait_for_virtual_device(timeout=3.0)
-        if result and result.get("device_id") is not None:
-            self._log.info(
-                "[CREATE] virtual dev=0x%04X btn=%s method=%s url=%s",
-                result.get("device_id", 0),
-                result.get("button_id"),
-                result.get("method"),
-                result.get("url"),
-            )
-        return result
+        # REMOTE_SYNC
+        sync_frame = self._build_frame(OP_REMOTE_SYNC, b"")
+        time.sleep(1)
+        self._log.info("[CREATE] sending REMOTE_SYNC")
+        self.transport.send_local(sync_frame)
+
+        time.sleep(1)
+        self._log.info(
+            "[CREATE] device '%s' created with id=%d, button='%s'",
+            device_name, device_id, button_name,
+        )
+        return {
+            "device_name": device_name,
+            "button_name": button_name,
+            "method": method,
+            "url": url,
+            "headers": headers,
+            "device_id": device_id,
+            "button_id": 1,
+            "status": "success",
+        }
 
     def add_ip_button_to_device(
         self,
@@ -1202,41 +1434,102 @@ class WifiDeviceMixin:
         method: str,
         url: str,
         headers: dict[str, str],
+        key_index: int = 1,
+        device_name: str | None = None,
+        body: str = "",
+        icon: int = 1,
     ) -> dict[str, Any] | None:
-        """Add an IP-backed command to an existing device."""
+        """Add an IP-backed command to an existing device using the native protocol.
 
+        ``key_index`` is the 1-based position of this button within the device.
+        The caller must track and increment this for each additional button.
+        ``device_name`` is needed for the CMD=8 commit frame; if omitted it is
+        looked up from the local state cache.
+        """
         if not self.can_issue_commands():
             self._log.info("[CREATE] add_ip_button_to_device ignored: proxy client is connected")
             return None
 
-        self.request_ip_commands_for_device(device_id, wait=True)
-        existing = self.state.ip_buttons.get(device_id & 0xFF, {})
-        next_button_id = (max(existing.keys()) + 1) if existing else 1
+        if device_name is None:
+            device_name = self.state.entities("device").get(
+                device_id & 0xFF, {}
+            ).get("name", f"Device {device_id}")
 
-        device_name = self.state.entities("device").get(device_id & 0xFF, {}).get("name", f"Device {device_id}")
+        overhead = b"\x01" + (1).to_bytes(2, "big")
 
-        opcode, payload = self._build_existing_device_frame(
+        # CMD=14: key sync
+        pulse = self._build_ip_pulse(method, url, headers, body=body)
+        key_frame = self._build_key_frame_x2(
+            key_index=key_index,
+            total_keys=key_index,
             device_id=device_id,
-            button_id=next_button_id,
-            button_name=button_name,
-            method=method,
-            url=url,
-            headers=headers,
+            key_id=key_index,
+            key_name=button_name,
+            ip=self._extract_host(url),
+            port=self._extract_port(url),
+            pulse=pulse,
         )
 
-        self.start_virtual_device(
-            device_name=device_name,
-            button_name=button_name,
-            method=method,
-            url=url,
-            headers=headers,
+        self._log.info(
+            "[CREATE] sending CMD=14 (key sync) dev=%d key='%s'",
+            device_id, button_name,
         )
+        self.transport.send_local(key_frame)
 
-        self._send_cmd_frame(opcode, payload)
+        # CMD=8: commit
+        target_ip = self._extract_host(url)
+        commit_data = self._build_device_data_x2(
+            device_name, device_id=device_id, commit=True,
+            target_ip=target_ip, icon=icon,
+        )
+        commit_frame = self._build_native_frame(NATIVE_CMD_COMMIT_DEVICE, overhead, commit_data)
 
-        result = self.wait_for_virtual_device(timeout=3.0)
-        self.request_ip_commands_for_device(device_id, wait=True)
-        return result
+        time.sleep(1)
+        self._log.info("[CREATE] sending CMD=8 (commit) dev=%d", device_id)
+        self.transport.send_local(commit_frame)
+
+        # REMOTE_SYNC
+        sync_frame = self._build_frame(OP_REMOTE_SYNC, b"")
+        time.sleep(1)
+        self._log.info("[CREATE] sending REMOTE_SYNC")
+        self.transport.send_local(sync_frame)
+
+        time.sleep(1)
+        self._log.info(
+            "[CREATE] added button '%s' to device %d ('%s')",
+            button_name, device_id, device_name,
+        )
+        return {
+            "device_name": device_name,
+            "button_name": button_name,
+            "method": method,
+            "url": url,
+            "headers": headers,
+            "device_id": device_id,
+            "button_id": key_index,
+            "status": "success",
+        }
+
+    def disable_device_power_control(self, device_id: int) -> bool:
+        """Set ``powerMode=4`` (no automatic power control) for a device.
+
+        Sends CMD=0x41 with ``[device_id, 0x04]`` to the hub, which maps to
+        the app's "No, disable automatic power control" option in
+        ``PowerConfigurationActivity``.  Must be called after the device is
+        committed (CMD=8) so the hub recognises the device ID.
+        """
+        if not self.can_issue_commands():
+            return False
+
+        self.reset_ack_queues()
+        self._log.info("[POWER] disabling automatic power control for dev=%d (powerMode=4)", device_id)
+        return self._send_native_step(
+            step_name=f"power-disable[dev={device_id}]",
+            family=NATIVE_CMD_POWER_MODE_SET,
+            payload=bytes([device_id, 0x04]),
+            ack_opcode=0x0103,
+            timeout=5.0,
+        )
 
 
 __all__ = ["WifiDeviceMixin"]

--- a/custom_components/sofabaton_x1s/lib/x1_proxy.py
+++ b/custom_components/sofabaton_x1s/lib/x1_proxy.py
@@ -433,6 +433,11 @@ class X1Proxy(IrBlobMixin, CatalogMixin, AckWaitersMixin, ActivityOpsMixin, Cach
         self._df_h2a = Deframer()
         self._df_a2h = Deframer()
         self._adv_started = False
+        # Set to True while programmatic native device/activity creation is in
+        # progress.  When set, OP_REQ_DEVICES forwarded by the companion app is
+        # suppressed so the hub does not interrupt the multi-frame creation
+        # sequence with a catalog burst.
+        self.native_creating: bool = False
 
         self.state = ActivityCache()
         self._button_assembler = DeviceButtonAssembler()
@@ -1825,6 +1830,12 @@ class X1Proxy(IrBlobMixin, CatalogMixin, AckWaitersMixin, ActivityOpsMixin, Cach
     def _handle_app_frames(self, frames: List[Tuple[int, bytes, bytes, int, int]]) -> None:
         for opcode, _raw, _payload, _scid, _ecid in frames:
             if opcode == OP_REQ_DEVICES:
+                if self.native_creating:
+                    # Suppress catalog polling while native device/activity
+                    # creation is in progress to avoid interrupting multi-frame
+                    # sequences with a device burst from the hub.
+                    self._log.debug("[CREATE] suppressing OP_REQ_DEVICES during native_creating")
+                    continue
                 self._begin_device_request()
                 self._app_devices_deadline = time.monotonic() + 1.0
                 self._app_devices_retry_sent = False
@@ -1837,6 +1848,76 @@ class X1Proxy(IrBlobMixin, CatalogMixin, AckWaitersMixin, ActivityOpsMixin, Cach
     def _clear_app_device_retry(self) -> None:
         self._app_devices_deadline = None
         self._app_devices_retry_sent = False
+
+    # ------------------------------------------------------------------
+    # Native protocol helper — step-with-ack
+    # ------------------------------------------------------------------
+
+    def _send_native_step(
+        self,
+        *,
+        step_name: str,
+        family: int,
+        payload: bytes,
+        ack_opcode: int,
+        ack_first_byte: int | None = None,
+        ack_fallback_opcodes: tuple[int, ...] = (),
+        timeout: float = 5.0,
+        retries: int = 0,
+        retry_delay: float = 0.0,
+    ) -> bool:
+        """Send a single-family frame and wait for an ACK.
+
+        Used by the native device/activity creation path (CMD=7/8/14/55/57/65).
+        Returns True on successful ACK, False on timeout.
+        """
+        candidates: list[tuple[int, int | None]] = [(ack_opcode, ack_first_byte)]
+        candidates.extend((op, None) for op in ack_fallback_opcodes)
+
+        total_attempts = max(1, int(retries) + 1)
+        for attempt in range(1, total_attempts + 1):
+            self._log.debug(
+                "[NATIVE][STEP] %s tx family=0x%02X expect_ack=0x%04X first_byte=%s attempt=%d/%d",
+                step_name,
+                family,
+                ack_opcode,
+                f"0x{ack_first_byte:02X}" if ack_first_byte is not None else "*",
+                attempt,
+                total_attempts,
+            )
+            self._send_family_frame(family, payload)
+
+            matched = self.wait_for_ack_any(candidates, timeout=timeout)
+            if matched is not None:
+                matched_opcode, _matched_payload = matched
+                if matched_opcode != ack_opcode:
+                    self._log.warning(
+                        "[NATIVE][STEP] %s matched fallback ack=0x%04X (expected=0x%04X)",
+                        step_name,
+                        matched_opcode,
+                        ack_opcode,
+                    )
+                self._log.debug("[NATIVE][STEP] %s acked via 0x%04X", step_name, matched_opcode)
+                return True
+
+            if attempt < total_attempts:
+                self._log.warning(
+                    "[NATIVE][STEP] %s retrying after ack timeout (attempt %d/%d)",
+                    step_name,
+                    attempt,
+                    total_attempts,
+                )
+                if retry_delay > 0:
+                    import time as _time  # noqa: PLC0415
+                    _time.sleep(retry_delay)
+
+        self._log.warning(
+            "[NATIVE][STEP] %s failed waiting ack=0x%04X first_byte=%s",
+            step_name,
+            ack_opcode,
+            f"0x{ack_first_byte:02X}" if ack_first_byte is not None else "*",
+        )
+        return False
 
     def parse_device_commands(self, payload: bytes, dev_id: int) -> Dict[int, str]:
         """Parse an assembled REQ_COMMANDS body using the fixed-width schema.

--- a/docs/examples/pyscript_provision.py
+++ b/docs/examples/pyscript_provision.py
@@ -1,0 +1,434 @@
+"""SofaBaton X1S hub provisioning example — nuke & repopulate via Pyscript.
+
+This script demonstrates how to use the ``create_ip_button``,
+``add_ip_button_to_device``, ``create_activity``, ``delete_device`` and
+``delete_activity`` services added by this integration to fully manage a
+SofaBaton X1S hub programmatically from Home Assistant, without ever opening
+the SofaBaton app.
+
+Requirements
+------------
+- `Pyscript <https://github.com/custom-components/pyscript>`_ custom integration
+- This file placed at ``<config>/pyscript/sofabaton_provision.py``
+- Pyscript ``allow_all_imports: true`` in ``configuration.yaml``
+
+Usage
+-----
+1. Close the SofaBaton app (hub only accepts direct commands when app is disconnected).
+2. In Developer Tools → Services, call ``pyscript.sofabaton_provision``.
+3. A persistent notification appears with the full result log.
+
+The script is safe to re-run at any time — it nukes all existing devices and
+activities first, then recreates them from the ``DEVICES``/``ACTIVITIES``
+config dicts below.
+
+X1S icon IDs (nicon_1 … nicon_16)
+----------------------------------
+  1=Monitor   2=Photo       3=Music       4=3D-glasses   5=Clapperboard
+  6=Handheld  7=Controller  8=STB/Router  9=AV-Receiver  10=Projector
+  11=Speakers 12=Lightbulb  13=Apple      14=Roku         15=Amazon
+  16=Nvidia/N
+"""
+
+import json as _json
+from functools import partial as _partial
+
+
+# ---------------------------------------------------------------------------
+#  Configuration — edit to match your setup
+# ---------------------------------------------------------------------------
+
+# Base URL for Home Assistant webhooks.
+# Adjust if HA is on a different address or port.
+HA_WEBHOOK_BASE = "http://192.168.1.1:8123/api/webhook"
+DEFAULT_HEADERS = {"Content-Type": "application/json"}
+DEFAULT_METHOD = "POST"
+
+# Map of virtual device name → button list and metadata.
+# Each button press sends:
+#   POST <webhook_base>/<webhook>  body: {"<body_key>": "<button_name>"}
+DEVICES = {
+    "Projector": {
+        "webhook": "cinema-projector",
+        "body_key": "cmd",
+        "icon": 10,   # Projector icon
+        "buttons": [
+            "PowerOn", "PowerOff",
+            "UP", "DOWN", "LEFT", "RIGHT", "ENTER", "RETURN",
+            "HOME", "MENU",
+            "VOLUP", "VOLDOWN", "MUTE",
+            "InputSource", "Settings",
+            "YouTube", "Netflix", "PrimeVideo", "DisneyPlus",
+        ],
+    },
+    "Apple TV": {
+        "webhook": "cinema-appletv",
+        "body_key": "cmd",
+        "icon": 13,   # Apple icon
+        "buttons": [
+            "PowerOn", "PowerOff",
+            "Home", "DirectionUp", "DirectionDown",
+            "DirectionLeft", "DirectionRight", "Select",
+            "Back", "Menu",
+            "Play", "Pause", "PlayPause",
+            "Rewind", "FastForward",
+            "VolumeUp", "VolumeDown", "VolumeMute",
+        ],
+    },
+    "Soundbar": {
+        "webhook": "cinema-soundbar",
+        "body_key": "cmd",
+        "icon": 11,   # Speakers icon
+        "buttons": [
+            "PowerOn", "PowerOff",
+            "VolumeUp", "VolumeDown", "VolumeMute",
+            "Source", "SoundMode",
+            "BassUp", "BassDown",
+            "Settings", "Info",
+        ],
+    },
+    # "Cinema" is a special control device whose buttons are used as
+    # power-on/off macros in activities. Its webhook notifies HA which
+    # activity to launch/tear down.
+    "Cinema": {
+        "webhook": "cinema-activity",
+        "body_key": "act",
+        "icon": 12,   # Lightbulb icon
+        "buttons": [
+            "appletv", "off",
+        ],
+    },
+}
+
+# Activities map activity name → member devices + power macro config.
+# ``power_on_btn`` must be a button name from the "Cinema" device.
+# ``power_off_btn`` must also be a button name from the "Cinema" device.
+ACTIVITIES = {
+    "Apple TV": {
+        "member_devices": ["Projector", "Soundbar", "Apple TV", "Cinema"],
+        "power_on_btn": "appletv",
+        "power_off_btn": "off",
+        "icon": 13,   # Apple icon
+        "color_id": 0,
+    },
+}
+
+# Timing (seconds) — reduce if your hub is fast, increase if you see failures
+INTER_DEVICE_SETTLE = 8   # pause between creating each device
+INTER_BUTTON_DELAY = 0.5  # pause between adding each button
+
+
+# ---------------------------------------------------------------------------
+#  Internal state
+# ---------------------------------------------------------------------------
+
+_provision_running = False
+
+
+# ---------------------------------------------------------------------------
+#  Helpers
+# ---------------------------------------------------------------------------
+
+def _get_hub():
+    """Return the first SofaBaton hub instance from hass.data."""
+    dd = hass.data.get("sofabaton_x1s", {})
+    for v in dd.values():
+        if hasattr(v, "_proxy") and hasattr(v, "entry_id"):
+            return v
+    return None
+
+
+def _notify(msg, title="SofaBaton Provision"):
+    """Create or update a persistent notification."""
+    persistent_notification.create(
+        message=msg, title=title, notification_id="sofabaton_provision",
+    )
+
+
+def _make_body(body_key, btn_name):
+    """Build a compact JSON body string for a button webhook."""
+    return _json.dumps({body_key: btn_name}, separators=(",", ":"))
+
+
+def _cinema_btn_index(btn_name):
+    """Return the 1-based index of *btn_name* in the Cinema device button list."""
+    buttons = DEVICES["Cinema"]["buttons"]
+    return buttons.index(btn_name) + 1  # hub uses 1-based slots
+
+
+# ---------------------------------------------------------------------------
+#  Pyscript services
+# ---------------------------------------------------------------------------
+
+@service
+def sofabaton_diag():
+    """Show hub connectivity and known device/activity IDs in a notification."""
+    hub = _get_hub()
+    if hub is None:
+        _notify("ERROR: no hub found in hass.data")
+        return
+
+    proxy = hub._proxy
+    can_cmd = task.executor(proxy.can_issue_commands)
+    known = sorted(task.executor(proxy.get_known_device_ids))
+    act_ids = sorted(task.executor(proxy.get_known_activity_ids))
+    devices, cached = task.executor(proxy.get_devices)
+
+    lines = [
+        f"can_issue_commands: {can_cmd}",
+        f"known device IDs: {known}",
+        f"known activity IDs: {act_ids}",
+        f"devices cached: {cached}",
+    ]
+    for dev_id, dev in sorted(devices.items()):
+        lines.append(f"  [{dev_id}] {dev.get('name', '?')}")
+
+    text = "\n".join(lines)
+    _notify(text, title="SofaBaton Diagnostics")
+    log.info("sofabaton_provision diag:\n%s", text)
+
+
+@service
+def sofabaton_nuke():
+    """Delete every device and activity from the hub."""
+    hub = _get_hub()
+    if hub is None:
+        _notify("ERROR: no hub found")
+        return
+
+    proxy = hub._proxy
+    if not task.executor(proxy.can_issue_commands):
+        _notify("BLOCKED: close the SofaBaton app first")
+        return
+
+    msgs = []
+
+    # Delete activities first (activities reference devices)
+    act_ids = sorted(task.executor(proxy.get_known_activity_ids))
+    if act_ids:
+        msgs.append(f"Deleting {len(act_ids)} activities: {act_ids}")
+        for act_id in act_ids:
+            ok = task.executor(proxy.delete_activity, act_id)
+            msgs.append(f"  {'OK' if ok else 'FAIL'} delete activity {act_id}")
+            task.sleep(0.5)
+
+    # Force-refresh device list in case cache is stale
+    known_ids = sorted(task.executor(proxy.get_known_device_ids))
+    if not known_ids:
+        task.executor(_partial(proxy.get_devices, force_refresh=True))
+        task.sleep(5)
+        known_ids = sorted(task.executor(proxy.get_known_device_ids))
+
+    if known_ids:
+        msgs.append(f"Deleting {len(known_ids)} devices: {known_ids}")
+        for dev_id in known_ids:
+            ok = task.executor(proxy.delete_device, dev_id)
+            msgs.append(f"  {'OK' if ok else 'FAIL'} delete device {dev_id}")
+            task.sleep(0.5)
+    else:
+        msgs.append("No devices to delete")
+
+    _notify("\n".join(msgs), title="SofaBaton Nuke Complete")
+
+
+@service
+def sofabaton_provision():
+    """Nuke all hub devices/activities, then recreate from the config dicts above."""
+    global _provision_running
+    if _provision_running:
+        _notify("Provision already running — ignoring duplicate call")
+        return
+    _provision_running = True
+    try:
+        _do_provision()
+    finally:
+        _provision_running = False
+
+
+# ---------------------------------------------------------------------------
+#  Core provisioning logic
+# ---------------------------------------------------------------------------
+
+def _do_provision():
+    hub = _get_hub()
+    if hub is None:
+        _notify("ERROR: no hub found")
+        return
+
+    proxy = hub._proxy
+    if not task.executor(proxy.can_issue_commands):
+        _notify("BLOCKED: close the SofaBaton app first")
+        return
+
+    msgs = ["**Nuke**"]
+
+    # ----- nuke -----
+    act_ids = sorted(task.executor(proxy.get_known_activity_ids))
+    if act_ids:
+        msgs.append(f"Deleting {len(act_ids)} activities: {act_ids}")
+        for act_id in act_ids:
+            ok = task.executor(proxy.delete_activity, act_id)
+            msgs.append(f"  {'OK' if ok else 'FAIL'} delete activity {act_id}")
+            task.sleep(0.5)
+
+    known_ids = sorted(task.executor(proxy.get_known_device_ids))
+    if not known_ids:
+        task.executor(_partial(proxy.get_devices, force_refresh=True))
+        task.sleep(5)
+        known_ids = sorted(task.executor(proxy.get_known_device_ids))
+
+    if known_ids:
+        msgs.append(f"Deleting {len(known_ids)} devices: {known_ids}")
+        for dev_id in known_ids:
+            ok = task.executor(proxy.delete_device, dev_id)
+            msgs.append(f"  {'OK' if ok else 'FAIL'} delete device {dev_id}")
+            task.sleep(0.5)
+    else:
+        msgs.append("No devices to delete")
+
+    _notify("\n".join(msgs) + "\n\n_Waiting for hub to settle…_")
+    task.sleep(10)
+
+    if not task.executor(proxy.can_issue_commands):
+        _notify("\n".join(msgs) + "\n\n**BLOCKED** after nuke — reopen app then close it again")
+        return
+
+    # ----- create devices -----
+    msgs.append("")
+    msgs.append("**Create Devices**")
+
+    # Suppress background OP_REQ_DEVICES polling while we are creating
+    proxy.native_creating = True
+    device_id_map: dict[str, int] = {}
+
+    try:
+        for dev_name, cfg in DEVICES.items():
+            buttons = cfg["buttons"]
+            url = f"{HA_WEBHOOK_BASE}/{cfg['webhook']}"
+            method = cfg.get("method", DEFAULT_METHOD)
+            headers = cfg.get("headers", DEFAULT_HEADERS)
+            body_key = cfg.get("body_key", "cmd")
+            icon = cfg.get("icon", 1)
+
+            # Create the device with its first button
+            try:
+                result = task.executor(
+                    _partial(
+                        proxy.create_ip_button,
+                        device_name=dev_name,
+                        button_name=buttons[0],
+                        method=method,
+                        url=url,
+                        headers=headers,
+                        body=_make_body(body_key, buttons[0]),
+                        icon=icon,
+                    )
+                )
+            except Exception as e:
+                msgs.append(f"EXCEPTION '{dev_name}': {e}")
+                task.sleep(INTER_DEVICE_SETTLE)
+                continue
+
+            device_id = (result or {}).get("device_id")
+            if device_id is None:
+                msgs.append(f"FAIL '{dev_name}' — no device_id")
+                task.sleep(INTER_DEVICE_SETTLE)
+                continue
+
+            device_id_map[dev_name] = device_id
+
+            # Add remaining buttons (key_index starts at 2 — first button is 1)
+            fail_count = 0
+            for idx, btn_name in enumerate(buttons[1:], start=2):
+                task.sleep(INTER_BUTTON_DELAY)
+                try:
+                    task.executor(
+                        _partial(
+                            proxy.add_ip_button_to_device,
+                            device_id=device_id,
+                            button_name=btn_name,
+                            method=method,
+                            url=url,
+                            headers=headers,
+                            key_index=idx,
+                            device_name=dev_name,
+                            body=_make_body(body_key, btn_name),
+                            icon=icon,
+                        )
+                    )
+                except Exception as e:
+                    fail_count += 1
+                    log.error("sofabaton_provision: add '%s' to '%s' failed: %s", btn_name, dev_name, e)
+
+            suffix = f" ({fail_count} fails)" if fail_count else ""
+            msgs.append(
+                f"OK '{dev_name}' id={device_id} icon={icon} ({len(buttons)} btns){suffix}"
+            )
+            task.sleep(INTER_DEVICE_SETTLE)
+    finally:
+        proxy.native_creating = False
+
+    # ----- create activities -----
+    msgs.append("")
+    msgs.append("**Create Activities**")
+
+    proxy.native_creating = True
+    try:
+        cinema_id = device_id_map.get("Cinema")
+        if cinema_id is None:
+            msgs.append("SKIP all activities — Cinema device not created")
+        else:
+            for act_name, act_cfg in ACTIVITIES.items():
+                member_ids = []
+                missing = []
+                for name in act_cfg["member_devices"]:
+                    did = device_id_map.get(name)
+                    if did is not None:
+                        member_ids.append(did)
+                    else:
+                        missing.append(name)
+
+                if missing:
+                    msgs.append(f"SKIP '{act_name}' — missing devices: {missing}")
+                    continue
+
+                on_btn = act_cfg["power_on_btn"]
+                off_btn = act_cfg.get("power_off_btn", "off")
+
+                # Steps: (type, device_id, 1-based key_index)
+                power_on_steps = [("cmd", cinema_id, _cinema_btn_index(on_btn))]
+                power_off_steps = [("cmd", cinema_id, _cinema_btn_index(off_btn))]
+
+                try:
+                    result = task.executor(
+                        _partial(
+                            proxy.create_activity,
+                            activity_name=act_name,
+                            member_device_ids=member_ids,
+                            power_on_steps=power_on_steps,
+                            power_off_steps=power_off_steps,
+                            icon=act_cfg.get("icon", 1),
+                            color_id=act_cfg.get("color_id", 0),
+                        )
+                    )
+                except Exception as e:
+                    msgs.append(f"EXCEPTION '{act_name}': {e}")
+                    task.sleep(5)
+                    continue
+
+                act_id = (result or {}).get("activity_id")
+                if act_id is not None:
+                    msgs.append(
+                        f"OK '{act_name}' id={act_id} icon={act_cfg.get('icon', 1)} "
+                        f"members={member_ids} on=Cinema[{on_btn}] off=Cinema[{off_btn}]"
+                    )
+                else:
+                    msgs.append(f"FAIL '{act_name}' — no activity_id")
+
+                task.sleep(5)
+    finally:
+        proxy.native_creating = False
+
+    summary = "\n".join(msgs)
+    _notify(summary, title="SofaBaton Provision Complete")
+    log.info("sofabaton_provision: DONE\n%s", summary)


### PR DESCRIPTION
## Summary

**Rebased on v0.5.9** (upstream `dev` branch now merged to `main`). All changes ported into the new modular mixin architecture.

- **Rewrites `create_ip_button` and `add_ip_button_to_device`** to use the hub's native binary TCP protocol (CMD=7/14/8 + REMOTE_SYNC) instead of the Roku/virtual-device replay path. Fits into the existing `WifiDeviceMixin` in `proxy_wifi_device.py`.
- **Adds `disable_device_power_control`** (CMD=0x41, powerMode=4) to `WifiDeviceMixin` — sets "No, disable automatic power control" for IP devices, preventing the app's "Not configured" warning.
- **Adds `create_activity`** (CMD=55 + CMD=18 power macros + `OP_ACTIVITY_DEVICE_CONFIRM`) and **`delete_activity`** (CMD=57) to `ActivityOpsMixin` in `proxy_activity_ops.py`.
- **Fixes `powerModel=1`** in the CMD=8 device commit payload so the app recognises power settings as present (byte 11 of the 60-byte cfg tail = 1).
- **Adds `native_creating` flag** on `X1Proxy` that suppresses `OP_REQ_DEVICES` forwarding during multi-frame native creation sequences.
- **Adds `_send_native_step`** to `X1Proxy` — a generic step-with-ACK helper using the new `wait_for_ack_any` / `reset_ack_queues` from `AckWaitersMixin`.
- **Adds `NATIVE_CMD_*` constants** (CMD=7/8/14/55/57/18 and power families 0x40-0x42) to `protocol_const.py`.
- **Enables 4 HA services**: `create_ip_button`, `create_activity`, `delete_activity`, `disable_device_power_control`.
- **Adds `docs/examples/pyscript_provision.py`**: a complete Pyscript example showing how to nuke and reprovision the hub from HA without the app.

## Motivation

The SofaBaton app is the only way to configure IP devices today. These changes allow fully scripted hub reprovisioning from Home Assistant (e.g. via a Pyscript), which is useful for disaster recovery, CI testing, and keeping hub configuration in version control.

## Example

`docs/examples/pyscript_provision.py` demonstrates the full workflow:

```python
# Create a device with multiple buttons
result = proxy.create_ip_button(
    device_name="Apple TV",
    button_name="PowerOn",
    method="POST",
    url="http://homeassistant.local:8123/api/webhook/cinema-appletv",
    headers={"Content-Type": "application/json"},
    body='{"cmd":"PowerOn"}',
    icon=13,
)
device_id = result["device_id"]

# Add more buttons to the same device
proxy.add_ip_button_to_device(
    device_id=device_id, button_name="PowerOff", key_index=2, ...
)

# Create an activity with member devices and power macros
proxy.create_activity(
    activity_name="Apple TV",
    member_device_ids=[projector_id, soundbar_id, appletv_id, cinema_id],
    power_on_steps=[("cmd", cinema_id, 1)],   # 1-based key slot
    power_off_steps=[("cmd", cinema_id, 5)],
    icon=13,
)

# Disable automatic power control for each device
proxy.disable_device_power_control(device_id)
```

## Protocol notes (X1S)

The hub uses a proprietary binary TCP protocol:
- Frame: `[0xA5][0x5A][LEN][CMD][data...][checksum]`
- Device creation: CMD=7 (create, 210-byte payload) → CMD=14 (key sync) → CMD=8 (commit) → CMD=100 (REMOTE_SYNC)
- Activity creation: CMD=55 → CMD=18 (power macros) → `OP_ACTIVITY_DEVICE_CONFIRM` (0x024F) per member
- Device/activity deletion: CMD=9 / CMD=57
- Power control: CMD=0x41 with `[device_id, 0x04]` sets powerMode=4 ("no automatic power control")
- `powerModel=1` in CMD=8 commit payload marks power settings as configured (prevents "Not configured" in app)
- All device/key names encoded as UTF-16BE, HTTP pulse strings as ASCII

Reverse-engineered from the SofaBaton Android APK (`PowerConfigurationActivity`, `ChooseDevicesAdpter`).

## Testing

Tested on a physical X1S hub (`model=X1S batch=20221120 fw=5`) with complete nuke-and-reprovision of 6 devices and 4 activities, verified via the SofaBaton app.

## Checklist

- [x] Tested on real hardware (X1S hub)
- [x] Existing `remote.send_command` and activity switching still work
- [x] No changes to config flow or entity setup
- [x] Rebased onto upstream v0.5.9 (post-dev-branch merge)

