### PR TITLE
Don't wipe the activity list on an empty activities burst

### DIFF
--- a/custom_components/sofabaton_x1s/hub.py
+++ b/custom_components/sofabaton_x1s/hub.py
@@ -568,7 +568,7 @@ class SofabatonHub:
                 len(acts) if acts else 0,
             )
             self.activities_ready = ready
-            if ready:
+            if ready and acts:
                 activities_changed = self._replace_activities(acts)
                 self._activities_generation += 1
                 if activities_changed:


### PR DESCRIPTION
Fixes #253.

`_on_activities_burst` replaced the activity catalog on every `ready` burst, even an empty one. So an empty-but-ready burst (`ready=True, count=0`) — which shows up right after activating an activity via `select.select_option` / `remote.turn_on` — wiped `self.activities` to `{}` and cleared `current_activity`. That's what collapsed `select.<hub>_activity` to just `Powered Off` and made `select.select_option` / `remote.turn_on` throw `ServiceValidationError`.

Just adding the same `if acts:` guard that `_on_activity_list_update` already uses:

```diff
             self.activities_ready = ready
-            if ready:
+            if ready and acts:
                 activities_changed = self._replace_activities(acts)
```

Tested on an X2 (proxy), 0.6.2, HA 2026.6.4: activating from HA no longer nukes the catalog, options stay put, select/turn_on work. Normal (non-empty) bursts and on-hub switching still update everything like before.
