### PR TITLE
Add services to rewrite the family-0x12 power rows (device and activity scope)

### DIFF
--- a/custom_components/sofabaton_x1s/__init__.py
+++ b/custom_components/sofabaton_x1s/__init__.py
@@ -3274,6 +3274,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if not hass.services.has_service(DOMAIN, "fetch_device_commands"):
         hass.services.async_register(DOMAIN, "fetch_device_commands", _async_handle_fetch_device_commands)
+    if not hass.services.has_service(DOMAIN, "set_power_macro"):
+        hass.services.async_register(
+            DOMAIN,
+            "set_power_macro",
+            _async_handle_set_power_macro,
+        )
+    if not hass.services.has_service(DOMAIN, "set_device_power_binding"):
+        hass.services.async_register(
+            DOMAIN,
+            "set_device_power_binding",
+            _async_handle_set_device_power_binding,
+        )
     if not hass.services.has_service(DOMAIN, "dump_ir_commands"):
         hass.services.async_register(
             DOMAIN,
@@ -3377,6 +3389,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.services.async_remove(DOMAIN, "restore_backup")
             hass.services.async_remove(DOMAIN, "play_ir_blob")
             hass.services.async_remove(DOMAIN, "persist_ir_blob")
+            hass.services.async_remove(DOMAIN, "set_device_power_binding")
+            hass.services.async_remove(DOMAIN, "set_power_macro")
             hass.services.async_remove(DOMAIN, "create_wifi_device")
             hass.services.async_remove(DOMAIN, "device_to_activity")
             hass.services.async_remove(DOMAIN, "delete_device")
@@ -3450,6 +3464,88 @@ async def _async_handle_fetch_device_commands(call: ServiceCall):
 
     ent_id = call.data["ent_id"]
     await hub.async_fetch_device_commands(ent_id)
+
+
+async def _async_handle_set_power_macro(call: ServiceCall):
+    hass = call.hass
+    hub = await _async_resolve_hub_from_call(hass, call)
+    if hub is None:
+        raise ValueError("Could not resolve Sofabaton hub from service call")
+
+    _raise_if_sync_in_progress(hub, "_async_handle_set_power_macro")
+
+    entity_id = int(call.data["entity_id"])
+    if entity_id < 1 or entity_id > 255:
+        raise ValueError("entity_id must be between 1 and 255")
+
+    button_raw = str(call.data["button"]).strip().lower()
+    button_map = {"power_on": 0xC6, "power_off": 0xC7}
+    if button_raw not in button_map:
+        raise ValueError("button must be power_on or power_off")
+
+    steps_raw = call.data.get("steps")
+    if not isinstance(steps_raw, list) or not steps_raw:
+        raise ValueError("steps must be a non-empty list of step objects")
+    steps: list[dict[str, int]] = []
+    for i, step in enumerate(steps_raw):
+        if not isinstance(step, dict):
+            raise ValueError(f"steps[{i}] must be an object")
+        for key in ("device_id", "command_id"):
+            if key not in step:
+                raise ValueError(f"steps[{i}] is missing {key}")
+            if int(step[key]) < 0 or int(step[key]) > 255:
+                raise ValueError(f"steps[{i}].{key} must be 0-255")
+        for key in ("duration", "delay"):
+            if int(step.get(key, 0)) < 0 or int(step.get(key, 0)) > 255:
+                raise ValueError(f"steps[{i}].{key} must be 0-255")
+        steps.append(
+            {
+                "device_id": int(step["device_id"]),
+                "command_id": int(step["command_id"]),
+                "duration": int(step.get("duration", 0)),
+                "delay": int(step.get("delay", 0)),
+            }
+        )
+
+    ok = await hub.async_set_power_macro(entity_id, button_map[button_raw], steps)
+    if not ok:
+        raise ValueError(
+            f"Hub did not ack power-macro write for entity {entity_id}"
+        )
+
+
+async def _async_handle_set_device_power_binding(call: ServiceCall):
+    hass = call.hass
+    hub = await _async_resolve_hub_from_call(hass, call)
+    if hub is None:
+        raise ValueError("Could not resolve Sofabaton hub from service call")
+
+    _raise_if_sync_in_progress(hub, "_async_handle_set_device_power_binding")
+
+    device_id = int(call.data["device_id"])
+    if device_id < 1 or device_id > 255:
+        raise ValueError("device_id must be between 1 and 255")
+
+    ids: dict[str, int | None] = {}
+    for key in ("power_on_command_id", "power_off_command_id"):
+        raw = call.data.get(key)
+        if raw is None:
+            ids[key] = None
+            continue
+        value = int(raw)
+        if value < 1 or value > 255:
+            raise ValueError(f"{key} must be between 1 and 255")
+        ids[key] = value
+    if ids["power_on_command_id"] is None and ids["power_off_command_id"] is None:
+        raise ValueError("Provide power_on_command_id and/or power_off_command_id")
+
+    ok = await hub.async_set_device_power_binding(
+        device_id,
+        power_on_command_id=ids["power_on_command_id"],
+        power_off_command_id=ids["power_off_command_id"],
+    )
+    if not ok:
+        raise ValueError(f"Hub did not ack power-binding write for device {device_id}")
 
 
 async def _async_handle_dump_ir_commands(call: ServiceCall):

--- a/custom_components/sofabaton_x1s/hub.py
+++ b/custom_components/sofabaton_x1s/hub.py
@@ -2398,6 +2398,40 @@ class SofabatonHub:
             )
         )
 
+    async def async_set_power_macro(
+        self,
+        entity_id: int,
+        button_id: int,
+        steps: list[dict[str, int]],
+    ) -> bool:
+        """Rewrite one power-macro row set on the selected hub."""
+
+        return await self.hass.async_add_executor_job(
+            partial(
+                self._proxy.set_power_macro,
+                entity_id,
+                button_id,
+                steps,
+            )
+        )
+
+    async def async_set_device_power_binding(
+        self,
+        device_id: int,
+        power_on_command_id: int | None = None,
+        power_off_command_id: int | None = None,
+    ) -> bool:
+        """Rewrite a device's POWER_ON/POWER_OFF rows on the selected hub."""
+
+        return await self.hass.async_add_executor_job(
+            partial(
+                self._proxy.set_device_power_binding,
+                device_id,
+                power_on_command_id=power_on_command_id,
+                power_off_command_id=power_off_command_id,
+            )
+        )
+
     async def async_command_to_button(
         self,
         activity_id: int,

--- a/custom_components/sofabaton_x1s/lib/proxy_activity_ops.py
+++ b/custom_components/sofabaton_x1s/lib/proxy_activity_ops.py
@@ -24,8 +24,9 @@ from .hub_versions import (
     HUB_VERSION_X2,
 )
 from .hub_logging import LogTag
-from .macros import MacroRecord
+from .macros import MacroKeyEntry, MacroRecord, build_macro_save_payload
 from .device_create import (
+    ACK_OPCODE_STATUS,
     FAMILY_REMOTE_SYNC,
     build_button_binding_step,
     synthesize_command_code,
@@ -1187,6 +1188,132 @@ class ActivityOpsMixin:
             "fav_id": new_fav_id,
             "status": "success",
         }
+
+    def set_power_macro(
+        self,
+        entity_id: int,
+        button_id: int,
+        steps: list[dict[str, int]],
+        *,
+        label: str = "",
+    ) -> bool:
+        """Rewrite one POWER_ON/POWER_OFF macro row set (family 0x12).
+
+        Generic form of :meth:`set_device_power_binding`: ``entity_id`` may
+        be a device id (device-side power rows) or an activity id (the
+        activity's power macro). ``steps`` are ``{device_id, command_id,
+        duration, delay}`` dicts written verbatim as the key sequence, in
+        the exact shape live activity power macros use (``fid=0`` on
+        X1S/X2).
+        """
+
+        if self.hub_version == HUB_VERSION_X1:
+            raise ValueError(
+                "set_power_macro is not implemented for X1 hubs "
+                "(X1 rows carry a synthetic command code in fid)"
+            )
+        if button_id not in (ButtonName.POWER_ON, ButtonName.POWER_OFF):
+            raise ValueError("button_id must be POWER_ON (0xC6) or POWER_OFF (0xC7)")
+        if not steps:
+            raise ValueError("steps must be a non-empty list")
+        if not self.can_issue_commands():
+            self._log.info(
+                "[POWER_MACRO] set_power_macro ignored: proxy client is connected"
+            )
+            return False
+
+        ent_lo = entity_id & 0xFF
+        key_sequence = [
+            MacroKeyEntry(
+                device_id=int(step["device_id"]) & 0xFF,
+                key_id=int(step["command_id"]) & 0xFF,
+                fid=0,
+                duration=int(step.get("duration", 0)) & 0xFF,
+                delay=int(step.get("delay", 0)) & 0xFF,
+            )
+            for step in steps
+        ]
+        body = build_macro_save_payload(
+            activity_id=ent_lo,
+            key_id=button_id,
+            key_sequence=key_sequence,
+            label=label,
+            hub_version=self.hub_version,
+        )
+        self.reset_ack_queues()
+        step = self.execute_exchange(
+            step_name=f"power-macro[ent=0x{ent_lo:02X} btn=0x{button_id:02X} n={len(key_sequence)}]",
+            family=0x12,
+            payload=body,
+            ack_opcode=0x0112,
+            ack_first_byte=button_id,
+            ack_fallback_opcodes=(ACK_OPCODE_STATUS,),
+        )
+        return step.ok
+
+    def set_device_power_binding(
+        self,
+        device_id: int,
+        *,
+        power_on_command_id: int | None = None,
+        power_off_command_id: int | None = None,
+    ) -> bool:
+        """Rewrite a device's POWER_ON/POWER_OFF macro rows (family 0x12).
+
+        Every activity power macro resolves ``(dev, 0xC6)/(dev, 0xC7)``
+        through these device-side rows — the same mechanism
+        ``_sync_step_wifi_power_config`` rewrites for wifi devices — so the
+        rewrite propagates to every activity without touching any of them.
+        Rows are written in the shape observed on live IR devices: a single
+        key entry with ``fid=0`` (X1S/X2 firmware resolves the command by
+        id), ``duration=0``, ``delay=0``.
+        """
+
+        if self.hub_version == HUB_VERSION_X1:
+            raise ValueError(
+                "set_device_power_binding is not implemented for X1 hubs "
+                "(X1 rows carry a synthetic command code in fid)"
+            )
+        if not self.can_issue_commands():
+            self._log.info(
+                "[DEVICE_POWER] set_device_power_binding ignored: proxy client is connected"
+            )
+            return False
+
+        dev_lo = device_id & 0xFF
+        ok = True
+        for button_id, label, command_id in (
+            (ButtonName.POWER_ON, "POWER_ON", power_on_command_id),
+            (ButtonName.POWER_OFF, "POWER_OFF", power_off_command_id),
+        ):
+            if command_id is None:
+                continue
+            body = build_macro_save_payload(
+                activity_id=dev_lo,
+                key_id=button_id,
+                key_sequence=[
+                    MacroKeyEntry(
+                        device_id=dev_lo,
+                        key_id=command_id & 0xFF,
+                        fid=0,
+                        duration=0,
+                        delay=0,
+                    )
+                ],
+                label=label,
+                hub_version=self.hub_version,
+            )
+            self.reset_ack_queues()
+            step = self.execute_exchange(
+                step_name=f"device-power[dev=0x{dev_lo:02X} btn=0x{button_id:02X}]",
+                family=0x12,
+                payload=body,
+                ack_opcode=0x0112,
+                ack_first_byte=button_id,
+                ack_fallback_opcodes=(ACK_OPCODE_STATUS,),
+            )
+            ok = ok and step.ok
+        return ok
 
     def command_to_button(
         self,

--- a/custom_components/sofabaton_x1s/services.yaml
+++ b/custom_components/sofabaton_x1s/services.yaml
@@ -475,3 +475,76 @@ delete_favorite:
           min: 1
           max: 255
           mode: box
+
+set_device_power_binding:
+  name: Set device power binding
+  description: Rewrites a device's POWER_ON/POWER_OFF macro rows (the (dev,0xC6)/(dev,0xC7) rows every activity power macro resolves through) to point at the given command ids. Propagates to all activities without touching them. X1S/X2 only.
+  fields:
+    device:
+      name: Sofabaton hub
+      required: true
+      selector:
+        device:
+          integration: sofabaton_x1s
+    device_id:
+      name: Device id
+      description: Hub device id whose power rows should be rewritten.
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 255
+          mode: box
+    power_on_command_id:
+      name: Power on command id
+      description: Command id to bind to POWER_ON (0xC6). Omit to leave that row unchanged.
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 255
+          mode: box
+    power_off_command_id:
+      name: Power off command id
+      description: Command id to bind to POWER_OFF (0xC7). Omit to leave that row unchanged.
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 255
+          mode: box
+
+set_power_macro:
+  name: Set power macro
+  description: Rewrites one POWER_ON/POWER_OFF macro row set (family 0x12) for any entity id - a device id (device-side power rows) or an activity id (that activity's power macro). Steps are written verbatim. X1S/X2 only.
+  fields:
+    device:
+      name: Sofabaton hub
+      required: true
+      selector:
+        device:
+          integration: sofabaton_x1s
+    entity_id:
+      name: Entity id
+      description: Hub device id (device power rows) or activity id (activity power macro).
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 255
+          mode: box
+    button:
+      name: Button
+      description: Which power macro to rewrite.
+      required: true
+      selector:
+        select:
+          options:
+            - power_on
+            - power_off
+    steps:
+      name: Steps
+      description: 'List of step objects: {device_id, command_id, duration, delay}. Written verbatim as the key sequence.'
+      required: true
+      selector:
+        object:

--- a/docs/protocol/write-flows.md
+++ b/docs/protocol/write-flows.md
@@ -42,6 +42,23 @@ the official app's create flow (write key `0x00`, hub assigns the real key
 in the `0x0112` ack) is *not* required for a client that picks a free key
 itself. Bench-validated 2026-07-11.
 
+**Device-scoped power rows (family `0x12`)**: devices carry the same
+macro-row structure as activities, keyed on the device id (device and
+activity ids share one entity-id space). Every device stores two rows —
+key `0xC6` (POWER_ON) and key `0xC7` (POWER_OFF) — and every activity
+power macro resolves its per-device power steps `(dev, 0xC6)` /
+`(dev, 0xC7)` through them at run time. Rewriting a device's rows
+therefore changes the power behavior of every activity that references
+the device, without touching any activity record. The write is a bare
+single-row family-`0x12` save per key (`0x0112` ack keyed on the row id;
+no head write, no `0x41` enable, no activity write) — the same shape the
+wifi power-config sync path uses. The `set_device_power_binding` and
+`set_power_macro` services expose this write. Bench-validated on X1S
+2026-07-19: rewritten rows read back correctly and were resolved live by
+every activity power macro. Freshly built label slots were accepted on
+X1S; see the `label_slot` notes on `build_macro_save_payload` for the
+metadata-preserving variant some saves require.
+
 ---
 
 ## Standard device-create sequence

--- a/tests/test_power_macro_services.py
+++ b/tests/test_power_macro_services.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.sofabaton_x1s.const import HUB_VERSION_X1, HUB_VERSION_X1S
+from custom_components.sofabaton_x1s.lib.ack import AckOutcome, SendStepResult
+from custom_components.sofabaton_x1s.lib.macros import MacroKeyEntry, build_macro_save_payload
+from custom_components.sofabaton_x1s.lib.protocol_const import ButtonName
+from custom_components.sofabaton_x1s.lib.x1_proxy import X1Proxy
+
+integration = importlib.import_module("custom_components.sofabaton_x1s.__init__")
+
+
+def _proxy_with_capture(monkeypatch, hub_version: str) -> tuple[X1Proxy, list[dict]]:
+    proxy = X1Proxy(
+        "127.0.0.1",
+        proxy_enabled=False,
+        diag_dump=False,
+        diag_parse=False,
+        hub_version=hub_version,
+    )
+    exchanges: list[dict] = []
+
+    def _capture(**kwargs):
+        exchanges.append(kwargs)
+        return SendStepResult(outcome=AckOutcome.acked)
+
+    monkeypatch.setattr(proxy, "execute_exchange", _capture)
+    monkeypatch.setattr(proxy, "can_issue_commands", lambda: True)
+    monkeypatch.setattr(proxy, "reset_ack_queues", lambda: None)
+    return proxy, exchanges
+
+
+# ---------------------------------------------------------------------------
+# proxy: set_device_power_binding
+# ---------------------------------------------------------------------------
+
+
+def test_set_device_power_binding_writes_both_rows(monkeypatch) -> None:
+    proxy, exchanges = _proxy_with_capture(monkeypatch, HUB_VERSION_X1S)
+
+    ok = proxy.set_device_power_binding(
+        5, power_on_command_id=25, power_off_command_id=26
+    )
+
+    assert ok is True
+    assert [e["family"] for e in exchanges] == [0x12, 0x12]
+    assert [e["ack_opcode"] for e in exchanges] == [0x0112, 0x0112]
+    assert [e["ack_first_byte"] for e in exchanges] == [
+        ButtonName.POWER_ON,
+        ButtonName.POWER_OFF,
+    ]
+
+    for exchange, button_id, command_id, label in (
+        (exchanges[0], ButtonName.POWER_ON, 25, "POWER_ON"),
+        (exchanges[1], ButtonName.POWER_OFF, 26, "POWER_OFF"),
+    ):
+        expected = build_macro_save_payload(
+            activity_id=5,
+            key_id=button_id,
+            key_sequence=[
+                MacroKeyEntry(
+                    device_id=5, key_id=command_id, fid=0, duration=0, delay=0
+                )
+            ],
+            label=label,
+            hub_version=HUB_VERSION_X1S,
+        )
+        assert exchange["payload"] == expected
+        # Body layout sanity: [0x01][outer_seq_be16][0x01][pages_be16][ent][key][count].
+        assert exchange["payload"][6] == 5
+        assert exchange["payload"][7] == button_id
+        assert exchange["payload"][8] == 1
+
+
+def test_set_device_power_binding_skips_omitted_row(monkeypatch) -> None:
+    proxy, exchanges = _proxy_with_capture(monkeypatch, HUB_VERSION_X1S)
+
+    ok = proxy.set_device_power_binding(3, power_on_command_id=7)
+
+    assert ok is True
+    assert len(exchanges) == 1
+    assert exchanges[0]["ack_first_byte"] == ButtonName.POWER_ON
+
+
+def test_set_device_power_binding_rejects_x1(monkeypatch) -> None:
+    proxy, _exchanges = _proxy_with_capture(monkeypatch, HUB_VERSION_X1)
+
+    with pytest.raises(ValueError, match="not implemented for X1 hubs"):
+        proxy.set_device_power_binding(3, power_on_command_id=7)
+
+
+def test_set_device_power_binding_noop_when_client_connected(monkeypatch) -> None:
+    proxy, exchanges = _proxy_with_capture(monkeypatch, HUB_VERSION_X1S)
+    monkeypatch.setattr(proxy, "can_issue_commands", lambda: False)
+
+    ok = proxy.set_device_power_binding(3, power_on_command_id=7)
+
+    assert ok is False
+    assert exchanges == []
+
+
+# ---------------------------------------------------------------------------
+# proxy: set_power_macro
+# ---------------------------------------------------------------------------
+
+
+def test_set_power_macro_writes_activity_scope_rows(monkeypatch) -> None:
+    proxy, exchanges = _proxy_with_capture(monkeypatch, HUB_VERSION_X1S)
+
+    steps = [
+        {"device_id": 1, "command_id": 198, "duration": 0, "delay": 0},
+        {"device_id": 2, "command_id": 198, "duration": 0, "delay": 0},
+        {"device_id": 1, "command_id": 197, "duration": 2, "delay": 0},
+        {"device_id": 2, "command_id": 197, "duration": 0, "delay": 0},
+    ]
+    ok = proxy.set_power_macro(101, ButtonName.POWER_ON, steps)
+
+    assert ok is True
+    assert len(exchanges) == 1
+    exchange = exchanges[0]
+    assert exchange["family"] == 0x12
+    assert exchange["ack_opcode"] == 0x0112
+    assert exchange["ack_first_byte"] == ButtonName.POWER_ON
+
+    expected = build_macro_save_payload(
+        activity_id=101,
+        key_id=ButtonName.POWER_ON,
+        key_sequence=[
+            MacroKeyEntry(
+                device_id=step["device_id"],
+                key_id=step["command_id"],
+                fid=0,
+                duration=step["duration"],
+                delay=step["delay"],
+            )
+            for step in steps
+        ],
+        label="",
+        hub_version=HUB_VERSION_X1S,
+    )
+    assert exchange["payload"] == expected
+    assert exchange["payload"][6] == 101
+    assert exchange["payload"][7] == ButtonName.POWER_ON
+    assert exchange["payload"][8] == len(steps)
+
+
+def test_set_power_macro_validates_inputs(monkeypatch) -> None:
+    proxy, _exchanges = _proxy_with_capture(monkeypatch, HUB_VERSION_X1S)
+
+    with pytest.raises(ValueError, match="POWER_ON .0xC6. or POWER_OFF .0xC7."):
+        proxy.set_power_macro(101, 0x05, [{"device_id": 1, "command_id": 1}])
+    with pytest.raises(ValueError, match="non-empty list"):
+        proxy.set_power_macro(101, ButtonName.POWER_ON, [])
+
+    x1_proxy, _ = _proxy_with_capture(monkeypatch, HUB_VERSION_X1)
+    with pytest.raises(ValueError, match="not implemented for X1 hubs"):
+        x1_proxy.set_power_macro(101, ButtonName.POWER_ON, [{"device_id": 1, "command_id": 1}])
+
+
+# ---------------------------------------------------------------------------
+# service handlers
+# ---------------------------------------------------------------------------
+
+
+class _FakeConfigEntries:
+    def __init__(self, entry):
+        self._entry = entry
+
+    def async_get_entry(self, entry_id):
+        if self._entry and self._entry.entry_id == entry_id:
+            return self._entry
+        return None
+
+
+class _FakeHass:
+    def __init__(self, entry):
+        self.config_entries = _FakeConfigEntries(entry)
+
+
+class _FakeCall:
+    def __init__(self, data: dict, hass=None):
+        self.data = data
+        self.hass = hass if hass is not None else _FakeHass(None)
+
+
+class _FakeHub:
+    def __init__(self) -> None:
+        self.entry_id = "entry-1"
+        self.calls: list[dict] = []
+        self.result = True
+
+    async def async_set_device_power_binding(
+        self,
+        device_id: int,
+        power_on_command_id: int | None = None,
+        power_off_command_id: int | None = None,
+    ) -> bool:
+        self.calls.append(
+            {
+                "device_id": device_id,
+                "power_on_command_id": power_on_command_id,
+                "power_off_command_id": power_off_command_id,
+            }
+        )
+        return self.result
+
+    async def async_set_power_macro(
+        self, entity_id: int, button_id: int, steps: list[dict[str, int]]
+    ) -> bool:
+        self.calls.append(
+            {"entity_id": entity_id, "button_id": button_id, "steps": steps}
+        )
+        return self.result
+
+
+def _wire_hub(monkeypatch) -> tuple[_FakeHub, _FakeHass]:
+    hub = _FakeHub()
+    entry = SimpleNamespace(entry_id="entry-1", options={})
+    hass = _FakeHass(entry)
+
+    async def _resolve(hass, call):
+        return hub
+
+    monkeypatch.setattr(integration, "_async_resolve_hub_from_call", _resolve)
+    return hub, hass
+
+
+def test_power_binding_service_requires_a_command_id(monkeypatch) -> None:
+    _hub, hass = _wire_hub(monkeypatch)
+
+    with pytest.raises(ValueError, match="power_on_command_id and/or power_off_command_id"):
+        asyncio.run(
+            integration._async_handle_set_device_power_binding(
+                _FakeCall({"device_id": 3}, hass)
+            )
+        )
+
+
+def test_power_binding_service_validates_ranges(monkeypatch) -> None:
+    _hub, hass = _wire_hub(monkeypatch)
+
+    with pytest.raises(ValueError, match="device_id must be between 1 and 255"):
+        asyncio.run(
+            integration._async_handle_set_device_power_binding(
+                _FakeCall({"device_id": 0, "power_on_command_id": 7}, hass)
+            )
+        )
+    with pytest.raises(ValueError, match="power_on_command_id must be between 1 and 255"):
+        asyncio.run(
+            integration._async_handle_set_device_power_binding(
+                _FakeCall({"device_id": 3, "power_on_command_id": 300}, hass)
+            )
+        )
+
+
+def test_power_binding_service_accepts_valid_input(monkeypatch) -> None:
+    hub, hass = _wire_hub(monkeypatch)
+
+    asyncio.run(
+        integration._async_handle_set_device_power_binding(
+            _FakeCall(
+                {"device_id": "3", "power_on_command_id": "25", "power_off_command_id": 26},
+                hass,
+            )
+        )
+    )
+
+    assert hub.calls == [
+        {"device_id": 3, "power_on_command_id": 25, "power_off_command_id": 26}
+    ]
+
+
+def test_power_macro_service_validates_inputs(monkeypatch) -> None:
+    _hub, hass = _wire_hub(monkeypatch)
+
+    with pytest.raises(ValueError, match="button must be power_on or power_off"):
+        asyncio.run(
+            integration._async_handle_set_power_macro(
+                _FakeCall(
+                    {"entity_id": 101, "button": "toggle", "steps": [{"device_id": 1, "command_id": 1}]},
+                    hass,
+                )
+            )
+        )
+    with pytest.raises(ValueError, match="steps must be a non-empty list"):
+        asyncio.run(
+            integration._async_handle_set_power_macro(
+                _FakeCall({"entity_id": 101, "button": "power_on", "steps": []}, hass)
+            )
+        )
+    with pytest.raises(ValueError, match=r"steps\[0\] is missing command_id"):
+        asyncio.run(
+            integration._async_handle_set_power_macro(
+                _FakeCall(
+                    {"entity_id": 101, "button": "power_on", "steps": [{"device_id": 1}]},
+                    hass,
+                )
+            )
+        )
+
+
+def test_power_macro_service_accepts_valid_input(monkeypatch) -> None:
+    hub, hass = _wire_hub(monkeypatch)
+
+    asyncio.run(
+        integration._async_handle_set_power_macro(
+            _FakeCall(
+                {
+                    "entity_id": "101",
+                    "button": "power_off",
+                    "steps": [
+                        {"device_id": "2", "command_id": "199"},
+                        {"device_id": 1, "command_id": 199, "duration": 3, "delay": 0},
+                    ],
+                },
+                hass,
+            )
+        )
+    )
+
+    assert hub.calls == [
+        {
+            "entity_id": 101,
+            "button_id": 0xC7,
+            "steps": [
+                {"device_id": 2, "command_id": 199, "duration": 0, "delay": 0},
+                {"device_id": 1, "command_id": 199, "duration": 3, "delay": 0},
+            ],
+        }
+    ]


### PR DESCRIPTION
The integration can back up and restore the family-0x12 power rows, and the wifi sync path already rewrites them internally in `_sync_step_wifi_power_config`, but for a normal IR device there is no way to edit them without the phone app. This adds that write as two services.

The itch I was scratching: my AVR's database profile only has a power toggle, so every activity power-on macro would flip the receiver off whenever it was already on (session started over CEC, or a mid-session activity switch). `persist_ir_blob` let me add proper discrete on/off IR commands, but nothing could point the device's POWER_ON/POWER_OFF rows at them. With these services the whole fix happens from HA: persist the discrete blobs, rebind the rows. Every activity picks the change up immediately because activity power macros resolve `(dev, 0xC6)` / `(dev, 0xC7)` through the device rows at run time.

What's included:

* `set_device_power_binding`: point a device's POWER_ON/POWER_OFF rows at one command id each. The common case.
* `set_power_macro`: write a full row set for any entity id, device or activity scope, with steps passed verbatim. I used the activity scope to drop a stray keypress step from a power-on macro.
* Both are bare single-row family-0x12 writes acked on 0x0112, the same shape as the wifi power-config sync. New code calls `execute_exchange` directly, per the note on `_send_step`.
* X1 raises ValueError. The X1 fid convention (synthetic command code in the row fid) is not implemented and I have no X1 hardware to validate against.
* 11 tests: frame-level assertions against `build_macro_save_payload` plus service-handler validation in the `test_roku_service_validation.py` style. A new section in `docs/protocol/write-flows.md`. `services.yaml` entries.

Bench notes from an X1S (July 2026 firmware):

* Rows read back correctly through `backup_bundle` after the write. The hub normalizes the row delay byte to 0xFF on read-back.
* Verified live end to end: with the AVR already on, activating an activity left it on, where the old toggle row would have killed it. I watched the receiver over eISCP during the macro and its power state never flipped.
* Freshly built label slots were accepted, so I did not need the metadata-preserving `label_slot` variant described in the `build_macro_save_payload` docstring. If you would rather the service read-modify-write the label slot to be safe, I can change that.
* The activity-scope cascade caveat in write-flows.md applies as documented. I kept every device referenced when rewriting an activity row and saw no cascade.

Happy to rename or reshape either service if you want a different surface.
