### PR TITLE
Expose the editor sync engine as services (sync_from_snapshot, export_snapshot)

### DIFF
--- a/custom_components/sofabaton_x1s/__init__.py
+++ b/custom_components/sofabaton_x1s/__init__.py
@@ -1894,6 +1894,24 @@ async def _ws_backup_clear_result(hass: HomeAssistant, connection, msg: dict[str
 _ACTIVITY_SYNC_PREWRITE_FAILURES = {"plan", "unavailable", "stale_check"}
 
 
+class _EntitySyncRejected(HomeAssistantError):
+    """Raised by :func:`_async_prepare_entity_sync` when a sync request is
+    rejected before any write reaches the hub — busy, locked, or failing
+    payload validation.
+
+    ``code`` mirrors the WS ``connection.send_error`` vocabulary (``busy``
+    / ``unavailable`` / ``invalid_payload``) so ``_handle_entity_sync_ws``
+    can reproduce its original error codes after the shared prep step; the
+    ``sync_from_snapshot`` service collapses it to a plain
+    ``HomeAssistantError`` (services don't have a separate error-code
+    channel).
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
 def _validate_entity_sync_inputs(
     msg: dict[str, Any],
     *,
@@ -2061,7 +2079,17 @@ async def _run_entity_sync_operation(
     edited: dict[str, Any],
     entity_kind: str,
     entity_id: int,
-) -> None:
+) -> dict[str, Any]:
+    """Run one activity/device sync to completion against the registry.
+
+    Shared engine entry point for both transports: the WS handler fires
+    this as a background task (progress flows through the operation
+    registry a subscriber polls); the ``sync_from_snapshot`` service
+    awaits it directly and uses the returned outcome dict as its response
+    or failure message, since a service call has no separate progress
+    channel to subscribe to.
+    """
+
     registry = _backup_operation_registry(hass)
 
     pending_wifi_rename: dict[str, Any] | None = None
@@ -2096,16 +2124,17 @@ async def _run_entity_sync_operation(
                 progress_callback=_progress,
             )
     except Exception as err:  # pragma: no cover - defensive; executor traps its own
+        outcome = {"status": "failed", "message": str(err) or "Sync failed", "transient": True}
         registry.update(
             operation_id,
             status="failed",
             phase="failed",
-            message=str(err) or "Sync failed",
-            error=str(err) or "Sync failed",
+            message=outcome["message"],
+            error=outcome["message"],
             transient=True,
         )
         registry.dismiss_operation(operation_id)
-        return
+        return outcome
 
     if isinstance(result, dict) and str(result.get("status") or "") == "failed":
         failed_at = str(result.get("failed_at") or "")
@@ -2122,7 +2151,7 @@ async def _run_entity_sync_operation(
                 transient=True,
             )
             registry.dismiss_operation(operation_id)
-            return
+            return result
         registry.update(
             operation_id,
             status="failed",
@@ -2133,7 +2162,7 @@ async def _run_entity_sync_operation(
             completed_steps=int(result.get("completed_steps") or 0),
             result=result,
         )
-        return
+        return result
 
     # Success tail: refresh the persistent cache so cache_generation bumps and
     # the remote card / Hub tab pick up the new names, macros, and bindings
@@ -2192,6 +2221,65 @@ async def _run_entity_sync_operation(
         total_steps=completed_steps,
         result=result or {"status": "success"},
     )
+    return result or {"status": "success"}
+
+
+async def _async_prepare_entity_sync(
+    hass: HomeAssistant,
+    *,
+    hub: SofabatonHub,
+    entity_kind: str,
+    sync_input: Mapping[str, Any],
+    operation_label: str,
+) -> tuple[str, dict[str, Any], dict[str, Any], int]:
+    """Busy-guard, lock-guard, validate, and register one entity sync.
+
+    The half of ``_handle_entity_sync_ws`` that has nothing to do with the
+    websocket transport, split out so the ``sync_from_snapshot`` service
+    can run the identical pre-write gauntlet — same busy/lock checks,
+    same :func:`_validate_entity_sync_inputs` payload validation, same
+    operation-registry bookkeeping — before handing off to
+    :func:`_run_entity_sync_operation` (the engine entry point both
+    transports share).
+
+    Returns ``(operation_id, baseline, edited, entity_id)``. Raises
+    :class:`_EntitySyncRejected` for every rejection reason (busy, locked,
+    invalid payload); callers translate ``.code`` / ``str(err)`` into
+    their own transport's error shape.
+    """
+
+    registry = _backup_operation_registry(hass)
+    if registry.has_running_for_entry(hub.entry_id):
+        raise _EntitySyncRejected(
+            "busy",
+            "Another backup, restore, or sync operation is already running for this hub",
+        )
+
+    try:
+        _raise_if_hub_operation_locked(hass, hub, operation_label)
+        baseline, edited, entity_id = _validate_entity_sync_inputs(
+            sync_input,
+            entity_kind=entity_kind,
+            hub_version=getattr(hub, "version", None),
+        )
+    except HomeAssistantError as err:
+        raise _EntitySyncRejected("unavailable", str(err)) from err
+    except ValueError as err:
+        raise _EntitySyncRejected("invalid_payload", str(err)) from err
+
+    operation_id = registry.create(
+        kind=f"{entity_kind}_sync",
+        entry_id=hub.entry_id,
+        initial_state={
+            "status": "pending",
+            "phase": "queued",
+            "message": "Starting sync…",
+            "completed_steps": 0,
+            "total_steps": 0,
+            f"current_{entity_kind}_id": entity_id,
+        },
+    )
+    return operation_id, baseline, edited, entity_id
 
 
 async def _handle_entity_sync_ws(
@@ -2206,37 +2294,18 @@ async def _handle_entity_sync_ws(
         connection.send_error(msg["id"], "not_found", "Could not resolve Sofabaton hub")
         return
 
-    registry = _backup_operation_registry(hass)
-    if registry.has_running_for_entry(hub.entry_id):
-        connection.send_error(msg["id"], "busy", "Another backup, restore, or sync operation is already running for this hub")
-        return
-
     try:
-        _raise_if_hub_operation_locked(hass, hub, f"_ws_{entity_kind}_sync")
-        baseline, edited, entity_id = _validate_entity_sync_inputs(
-            msg,
+        operation_id, baseline, edited, entity_id = await _async_prepare_entity_sync(
+            hass,
+            hub=hub,
             entity_kind=entity_kind,
-            hub_version=getattr(hub, "version", None),
+            sync_input=msg,
+            operation_label=f"_ws_{entity_kind}_sync",
         )
-    except HomeAssistantError as err:
-        connection.send_error(msg["id"], "unavailable", str(err))
-        return
-    except ValueError as err:
-        connection.send_error(msg["id"], "invalid_payload", str(err))
+    except _EntitySyncRejected as err:
+        connection.send_error(msg["id"], err.code, str(err))
         return
 
-    operation_id = registry.create(
-        kind=f"{entity_kind}_sync",
-        entry_id=hub.entry_id,
-        initial_state={
-            "status": "pending",
-            "phase": "queued",
-            "message": "Starting sync…",
-            "completed_steps": 0,
-            "total_steps": 0,
-            f"current_{entity_kind}_id": entity_id,
-        },
-    )
     hass.async_create_task(
         _run_entity_sync_operation(
             hass,
@@ -3329,6 +3398,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.services.async_register(DOMAIN, "command_to_button", _async_handle_command_to_button)
     if not hass.services.has_service(DOMAIN, "sync_command_config"):
         hass.services.async_register(DOMAIN, "sync_command_config", _async_handle_sync_command_config)
+    if not hass.services.has_service(DOMAIN, "export_snapshot"):
+        hass.services.async_register(
+            DOMAIN,
+            "export_snapshot",
+            _async_handle_export_snapshot,
+            supports_response=SupportsResponse.OPTIONAL,
+        )
+    if not hass.services.has_service(DOMAIN, "sync_from_snapshot"):
+        hass.services.async_register(
+            DOMAIN,
+            "sync_from_snapshot",
+            _async_handle_sync_from_snapshot,
+            supports_response=SupportsResponse.OPTIONAL,
+        )
 
     hass.data[DOMAIN][entry.entry_id] = hub
 
@@ -3386,6 +3469,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.services.async_remove(DOMAIN, "delete_favorite")
             hass.services.async_remove(DOMAIN, "command_to_button")
             hass.services.async_remove(DOMAIN, "sync_command_config")
+            hass.services.async_remove(DOMAIN, "export_snapshot")
+            hass.services.async_remove(DOMAIN, "sync_from_snapshot")
             async_teardown_diagnostics(hass)
             if _get_lovelace_resource_mode(hass) == _LOVELACE_STORAGE_MODE:
                 if hass.data[DOMAIN].get("storage_resources_registered"):
@@ -3913,6 +3998,114 @@ async def _async_handle_sync_command_config(call: ServiceCall):
         device_key=str(payload.get("device_key") or device_key or ""),
         device_name=device_name,
     )
+
+
+async def _async_handle_export_snapshot(call: ServiceCall):
+    """Service handler for ``sofabaton_x1s.export_snapshot``.
+
+    Wraps :meth:`SofabatonHub.async_get_structural_bundle` — the exact
+    projection the live Control Panel editor reads (WS command
+    ``sofabaton_x1s/cache/structural_bundle``, see
+    ``_ws_get_structural_bundle``). It is a pure read from the cached
+    proxy state: no hub I/O and no per-command IR blob dump, so it is
+    cheap enough to call before every ``sync_from_snapshot`` and safe to
+    call while the vendor app owns the hub.
+
+    Deliberately not ``backup_bundle``: that action always does a live
+    round trip to the hub (and, for a whole-hub backup, dumps every
+    command's IR blob) — see ``docs/protocol/write-flows.md``.
+    ``export_snapshot`` only returns what the integration already has
+    cached; open the Control Panel's Hub or Activities tab once (or run
+    a whole-hub cache refresh) to populate the cache on a fresh install.
+    """
+
+    hass = call.hass
+    hub = await _async_resolve_hub_from_call(hass, call)
+    if hub is None:
+        raise ValueError("Could not resolve Sofabaton hub from service call")
+
+    store = await _async_get_persistent_cache_store(hass)
+    if not store.enabled:
+        raise HomeAssistantError(
+            "export_snapshot requires the persistent cache to be enabled "
+            "(Sofabaton X1S integration options)."
+        )
+
+    bundle = await hub.async_get_structural_bundle()
+    if not bundle:
+        raise HomeAssistantError(
+            "No cached structural snapshot is available yet. Open the "
+            "Control Panel's Hub or Activities tab once (or run a "
+            "whole-hub cache refresh) to populate it, then retry."
+        )
+    return {"bundle": bundle, "generation": hub.cache_generation}
+
+
+async def _async_handle_sync_from_snapshot(call: ServiceCall):
+    """Service handler for ``sofabaton_x1s.sync_from_snapshot``.
+
+    Script-callable counterpart of the live Control Panel editor's save
+    action. Accepts the same ``baseline``/``edited`` hub_bundle pair the
+    WS ``activity/sync`` and ``device/sync`` commands accept (see
+    ``_validate_entity_sync_inputs``), routes through the identical
+    pre-write gauntlet (``_async_prepare_entity_sync``: busy guard, lock
+    guard, payload validation, operation-registry bookkeeping) and the
+    identical engine entry point (``_run_entity_sync_operation`` ->
+    ``hub.async_sync_activity``/``async_sync_device`` ->
+    ``ActivitySyncMixin.sync_activity``/``sync_device``) the WS handler
+    uses — so paging, label-slot reuse, and ack tolerance all apply
+    exactly as they do from the Control Panel.
+
+    Typical flow: call ``export_snapshot`` to get a bundle, edit the two
+    POWER_ON/POWER_OFF steps for one device in the returned JSON, call
+    this with the untouched export as ``baseline`` and the edited copy
+    as ``edited``.
+    """
+
+    hass = call.hass
+    hub = await _async_resolve_hub_from_call(hass, call)
+    if hub is None:
+        raise ValueError("Could not resolve Sofabaton hub from service call")
+
+    entity_kind = str(call.data.get("entity_kind") or "").strip().lower()
+    if entity_kind not in ("activity", "device"):
+        raise ValueError("entity_kind must be 'activity' or 'device'")
+
+    baseline = call.data.get("baseline")
+    edited = call.data.get("edited")
+    if not isinstance(baseline, dict) or not isinstance(edited, dict):
+        raise ValueError("baseline and edited must be hub_bundle objects")
+
+    sync_input = {
+        "baseline": baseline,
+        "edited": edited,
+        f"{entity_kind}_id": call.data.get("entity_id"),
+    }
+
+    try:
+        operation_id, baseline, edited, entity_id = await _async_prepare_entity_sync(
+            hass,
+            hub=hub,
+            entity_kind=entity_kind,
+            sync_input=sync_input,
+            operation_label=f"sync_from_snapshot[{entity_kind}]",
+        )
+    except _EntitySyncRejected as err:
+        raise HomeAssistantError(str(err)) from err
+
+    result = await _run_entity_sync_operation(
+        hass,
+        operation_id,
+        hub=hub,
+        baseline=baseline,
+        edited=edited,
+        entity_kind=entity_kind,
+        entity_id=entity_id,
+    )
+    if isinstance(result, dict) and str(result.get("status") or "") == "failed":
+        raise HomeAssistantError(str(result.get("message") or "Sync failed"))
+    return result
+
 
 async def _async_resolve_hub_from_call(hass: HomeAssistant, call: ServiceCall):
     return await _async_resolve_hub_from_data(hass, call.data)

--- a/custom_components/sofabaton_x1s/__init__.py
+++ b/custom_components/sofabaton_x1s/__init__.py
@@ -1904,7 +1904,9 @@ class _EntitySyncRejected(HomeAssistantError):
     can reproduce its original error codes after the shared prep step; the
     ``sync_from_snapshot`` service collapses it to a plain
     ``HomeAssistantError`` (services don't have a separate error-code
-    channel).
+    channel). ``stale_baseline`` belongs to the service-only
+    ``expected_generation`` guard and never reaches the WS path, which
+    does not send an expected generation.
     """
 
     def __init__(self, code: str, message: str) -> None:
@@ -2231,6 +2233,7 @@ async def _async_prepare_entity_sync(
     entity_kind: str,
     sync_input: Mapping[str, Any],
     operation_label: str,
+    expected_generation: int | None = None,
 ) -> tuple[str, dict[str, Any], dict[str, Any], int]:
     """Busy-guard, lock-guard, validate, and register one entity sync.
 
@@ -2242,10 +2245,17 @@ async def _async_prepare_entity_sync(
     :func:`_run_entity_sync_operation` (the engine entry point both
     transports share).
 
+    ``expected_generation`` is the service path's baseline-freshness gate:
+    when supplied, the hub's ``cache_generation`` must still equal it or
+    the sync is refused. The WS editor never passes it — it re-exports its
+    baseline from the structural bundle after every sync and relies on the
+    engine's own stale-check preflight, which stays the wire-level
+    authority for both transports.
+
     Returns ``(operation_id, baseline, edited, entity_id)``. Raises
-    :class:`_EntitySyncRejected` for every rejection reason (busy, locked,
-    invalid payload); callers translate ``.code`` / ``str(err)`` into
-    their own transport's error shape.
+    :class:`_EntitySyncRejected` for every rejection reason (busy, stale
+    baseline, locked, invalid payload); callers translate ``.code`` /
+    ``str(err)`` into their own transport's error shape.
     """
 
     registry = _backup_operation_registry(hass)
@@ -2254,6 +2264,23 @@ async def _async_prepare_entity_sync(
             "busy",
             "Another backup, restore, or sync operation is already running for this hub",
         )
+
+    # The generation compare sits after the busy guard (no registry-tracked
+    # operation is mid-flight for this entry, so no sync tail is about to
+    # bump the generation) and before ``registry.create`` (a stale request
+    # must not consume an operation slot other callers would see as busy).
+    # Everything from here through ``create`` is await-free, so the value
+    # read cannot move before the operation is registered; the successful
+    # sync's own bump happens later, inside ``_run_entity_sync_operation``'s
+    # tail, and is never re-checked against this snapshot.
+    if expected_generation is not None:
+        current_generation = int(hub.cache_generation)
+        if current_generation != expected_generation:
+            raise _EntitySyncRejected(
+                "stale_baseline",
+                f"stale baseline: expected generation {expected_generation}, "
+                f"hub cache is at {current_generation} - re-export the snapshot",
+            )
 
     try:
         _raise_if_hub_operation_locked(hass, hub, operation_label)
@@ -4017,6 +4044,11 @@ async def _async_handle_export_snapshot(call: ServiceCall):
     ``export_snapshot`` only returns what the integration already has
     cached; open the Control Panel's Hub or Activities tab once (or run
     a whole-hub cache refresh) to populate the cache on a fresh install.
+
+    Response is ``{bundle, generation}`` — the same shape the WS command
+    sends. ``generation`` is the cache generation the snapshot was
+    exported at; pass it back as ``sync_from_snapshot``'s
+    ``expected_generation`` to refuse a stale baseline loudly.
     """
 
     hass = call.hass
@@ -4056,10 +4088,13 @@ async def _async_handle_sync_from_snapshot(call: ServiceCall):
     uses — so paging, label-slot reuse, and ack tolerance all apply
     exactly as they do from the Control Panel.
 
-    Typical flow: call ``export_snapshot`` to get a bundle, edit the two
-    POWER_ON/POWER_OFF steps for one device in the returned JSON, call
-    this with the untouched export as ``baseline`` and the edited copy
-    as ``edited``.
+    Typical flow: call ``export_snapshot`` to get a bundle, keep the
+    ``generation`` it returns, edit the two POWER_ON/POWER_OFF steps for
+    one device in the returned JSON, then call this with the untouched
+    export as ``baseline``, the edited copy as ``edited``, and that
+    generation as ``expected_generation`` — the sync then refuses loudly
+    if the hub cache has moved since the export instead of failing later
+    (or writing against a rebased diff).
     """
 
     hass = call.hass
@@ -4076,6 +4111,14 @@ async def _async_handle_sync_from_snapshot(call: ServiceCall):
     if not isinstance(baseline, dict) or not isinstance(edited, dict):
         raise ValueError("baseline and edited must be hub_bundle objects")
 
+    raw_generation = call.data.get("expected_generation")
+    expected_generation: int | None = None
+    if raw_generation is not None:
+        try:
+            expected_generation = int(raw_generation)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("expected_generation must be an integer") from exc
+
     sync_input = {
         "baseline": baseline,
         "edited": edited,
@@ -4089,6 +4132,7 @@ async def _async_handle_sync_from_snapshot(call: ServiceCall):
             entity_kind=entity_kind,
             sync_input=sync_input,
             operation_label=f"sync_from_snapshot[{entity_kind}]",
+            expected_generation=expected_generation,
         )
     except _EntitySyncRejected as err:
         raise HomeAssistantError(str(err)) from err

--- a/custom_components/sofabaton_x1s/services.yaml
+++ b/custom_components/sofabaton_x1s/services.yaml
@@ -475,3 +475,69 @@ delete_favorite:
           min: 1
           max: 255
           mode: box
+
+export_snapshot:
+  name: Export hub snapshot
+  description: >-
+    Returns the structural hub_bundle the live Control Panel editor reads --
+    cached proxy state only, no hub round trip and no per-command IR blob
+    dump (that is what backup_bundle is for). Requires the persistent cache
+    to be enabled and populated; open the Control Panel's Hub or Activities
+    tab once, or run a whole-hub cache refresh, to populate it on a fresh
+    install. Edit the returned JSON offline and pass it back to
+    sync_from_snapshot as baseline/edited to write just the changed rows.
+  fields:
+    device:
+      name: Sofabaton hub
+      required: true
+      selector:
+        device:
+          integration: sofabaton_x1s
+
+sync_from_snapshot:
+  name: Sync edited snapshot
+  description: >-
+    Script-callable counterpart of the live Control Panel editor's save
+    action. Diffs baseline against edited (both hub_bundle payloads from
+    export_snapshot) and writes only the rows that changed for the selected
+    activity or device -- the same engine the editor drives, so multi-page
+    macro saves, label-slot handling, and ack tolerance all apply the same
+    way. Fails if a backup, restore, or sync operation is already running
+    for this hub, or if the app client currently owns the hub.
+  fields:
+    device:
+      name: Sofabaton hub
+      required: true
+      selector:
+        device:
+          integration: sofabaton_x1s
+    entity_kind:
+      name: Entity kind
+      description: Whether entity_id below names an activity or a device.
+      required: true
+      selector:
+        select:
+          options:
+            - activity
+            - device
+    entity_id:
+      name: Entity id
+      description: Hub device id or activity id to sync. Must be present in both baseline and edited.
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 255
+          mode: box
+    baseline:
+      name: Baseline snapshot
+      description: The unedited hub_bundle returned by export_snapshot, establishing what changed.
+      required: true
+      selector:
+        object:
+    edited:
+      name: Edited snapshot
+      description: Your offline-edited copy of the baseline hub_bundle. Only the rows that differ from baseline are written.
+      required: true
+      selector:
+        object:

--- a/custom_components/sofabaton_x1s/services.yaml
+++ b/custom_components/sofabaton_x1s/services.yaml
@@ -481,11 +481,14 @@ export_snapshot:
   description: >-
     Returns the structural hub_bundle the live Control Panel editor reads --
     cached proxy state only, no hub round trip and no per-command IR blob
-    dump (that is what backup_bundle is for). Requires the persistent cache
-    to be enabled and populated; open the Control Panel's Hub or Activities
-    tab once, or run a whole-hub cache refresh, to populate it on a fresh
-    install. Edit the returned JSON offline and pass it back to
-    sync_from_snapshot as baseline/edited to write just the changed rows.
+    dump (that is what backup_bundle is for). The response carries the
+    bundle plus the cache generation it was exported at; pass that
+    generation to sync_from_snapshot's expected_generation to catch a stale
+    baseline. Requires the persistent cache to be enabled and populated;
+    open the Control Panel's Hub or Activities tab once, or run a
+    whole-hub cache refresh, to populate it on a fresh install. Edit the
+    returned JSON offline and pass it back to sync_from_snapshot as
+    baseline/edited to write just the changed rows.
   fields:
     device:
       name: Sofabaton hub
@@ -528,6 +531,14 @@ sync_from_snapshot:
         number:
           min: 1
           max: 255
+          mode: box
+    expected_generation:
+      name: Expected cache generation
+      description: Generation returned by export_snapshot when the baseline was taken; the sync refuses loudly if the hub cache has moved past it. Omit to skip the freshness check.
+      required: false
+      selector:
+        number:
+          min: 0
           mode: box
     baseline:
       name: Baseline snapshot

--- a/docs/protocol/write-flows.md
+++ b/docs/protocol/write-flows.md
@@ -42,6 +42,17 @@ the official app's create flow (write key `0x00`, hub assigns the real key
 in the `0x0112` ack) is *not* required for a client that picks a free key
 itself. Bench-validated 2026-07-11.
 
+**Editor sync engine owns this family**: the paging, label-slot-reuse, and
+ack-tolerance behavior described above lives in `ActivitySyncMixin` /
+`X1Proxy._send_paged_macro_save` (`lib/proxy_activity_sync.py`,
+`lib/x1_proxy.py`), driven by a baseline/edited `hub_bundle` diff
+(`lib/activity_sync.py`). The live Control Panel editor's save action and
+the `sync_from_snapshot` HA service (`export_snapshot` supplies the
+baseline) are two entry points into that same engine, not separate write
+paths — a device- or activity-scoped power-row edit submitted through
+either one gets the paged write, the reused label slot, and the tolerant
+ack for free. See `services.yaml` for the service surface.
+
 ---
 
 ## Standard device-create sequence

--- a/tests/test_power_macro_rows.py
+++ b/tests/test_power_macro_rows.py
@@ -1,0 +1,230 @@
+"""Power-macro row coverage, retargeted from the withdrawn direct-write
+services onto the reused sync engine.
+
+Branch history: an earlier iteration of this work (PR #262) added two
+dedicated services, ``set_device_power_binding`` and ``set_power_macro``,
+that called ``build_macro_save_payload`` directly and sent it as a single
+``execute_exchange`` frame. The maintainer's review kept the test file's
+intent but not its target: that direct-write path regresses three
+behaviors the live Control Panel editor's sync engine already has to get
+right —
+
+1. macro saves above 18 rows need the paged write (``_send_paged_macro_save``);
+   a single-frame send delivers only page 1 of a payload whose own header
+   declares two,
+2. activity-scope saves must reuse the hub's ``raw_label_slot`` bytes or a
+   freshly built slot can be rejected with status ``0x0c``,
+3. the final ``0x0112`` ack does not always echo the button id, so a strict
+   first-byte match can report failure on a write that actually succeeded.
+
+This branch drops the two dedicated services and exposes the editor's own
+engine instead (``sync_from_snapshot`` / ``export_snapshot`` — see
+``tests/test_sync_from_snapshot_service.py``), so paging, label-slot reuse,
+and ack tolerance come along for free rather than needing to be
+reimplemented and re-guarded against regressing.
+
+What survives here from the withdrawn test file:
+
+* the frame-level ``build_macro_save_payload`` shape assertions — ported
+  as direct builder tests (no proxy, no service, no ``execute_exchange``
+  stub) instead of assertions about what a service handler happened to
+  call the builder with,
+* the row-count boundary from review point #1 above, encoded as a direct
+  regression test of ``build_macro_save_payload``'s own ``total_pages``
+  math,
+* one sync-engine-level test proving an activity-scope power macro that
+  crosses that boundary produces a payload the engine's own
+  ``_send_paged_macro_save`` will page correctly (see
+  ``tests/test_x1_proxy.py`` for proof that function then walks every
+  declared page and tolerates the ack).
+
+What does not survive (no equivalent needed):
+
+* "skips the omitted row" / "rejects X1" / "no-op when client connected" —
+  these guarded the withdrawn methods' own bespoke preconditions. The
+  reused engine's equivalent protections are structural, not per-method:
+  an omitted row is simply an unedited macro (no diff, no step — see
+  ``test_noop_returns_success_without_writes`` in
+  ``tests/test_activity_sync_exec.py``); "unavailable" is a single shared
+  gate in ``sync_activity``/``sync_device``
+  (``test_unavailable_when_cannot_issue_commands``); the engine does not
+  special-case X1 at all (device-scope power rows there go through the
+  OP_3212 device-create builder, not ``build_macro_save_payload``, on
+  every hub version alike — see
+  ``test_device_macro_write_uses_the_single_page_device_builder``).
+* input-validation ValueErrors for a bespoke ``steps``/``button`` shape —
+  the sync engine takes a full ``hub_bundle`` diff instead of an ad hoc
+  step list, so the equivalent protection lives in bundle validation
+  (e.g. ``_missing_shutdown_row`` in ``tests/test_activity_sync_ws.py``,
+  which rejects an edit that empties a power macro's steps entirely).
+"""
+
+from __future__ import annotations
+
+import copy
+
+from custom_components.sofabaton_x1s.const import HUB_VERSION_X1, HUB_VERSION_X1S
+from custom_components.sofabaton_x1s.lib.macros import MacroKeyEntry, build_macro_save_payload
+from custom_components.sofabaton_x1s.lib.protocol_const import ButtonName
+
+from tests.test_activity_sync_exec import FakeProxy
+from tests.test_activity_sync_plan import ACTIVITY_ID, _activity, base_bundle
+
+# ---------------------------------------------------------------------------
+# build_macro_save_payload: byte shape (ported from the withdrawn services'
+# execute_exchange-capture assertions)
+# ---------------------------------------------------------------------------
+
+
+def test_build_macro_save_payload_matches_device_power_binding_row_shape() -> None:
+    """Shape a device's POWER_ON/POWER_OFF row write used to assert via the
+    withdrawn ``set_device_power_binding`` proxy method: outer marker, a
+    single page declared, entity id, button id, and a one-entry key
+    sequence naming the bound command."""
+
+    for button_id, command_id, label in (
+        (ButtonName.POWER_ON, 25, "POWER_ON"),
+        (ButtonName.POWER_OFF, 26, "POWER_OFF"),
+    ):
+        payload = build_macro_save_payload(
+            activity_id=5,
+            key_id=button_id,
+            key_sequence=[
+                MacroKeyEntry(device_id=5, key_id=command_id, fid=0, duration=0, delay=0)
+            ],
+            label=label,
+            hub_version=HUB_VERSION_X1S,
+        )
+        # outer [0x01][seq_be16] + body [0x01][pages_be16][ent][key][count]
+        assert payload[0] == 0x01
+        assert payload[3] == 0x01
+        assert payload[4:6] == b"\x00\x01"  # single page
+        assert payload[6] == 5
+        assert payload[7] == button_id
+        assert payload[8] == 1
+        row = payload[9:19]
+        assert row[0] == 5  # device_id
+        assert row[1] == command_id  # key_id (bound command)
+
+
+def test_build_macro_save_payload_matches_activity_power_macro_row_shape() -> None:
+    """Shape an activity-scope multi-device power macro used to assert via
+    the withdrawn ``set_power_macro`` proxy method: one entry per step, in
+    the order supplied."""
+
+    steps = [
+        {"device_id": 1, "command_id": 198, "duration": 0, "delay": 0},
+        {"device_id": 2, "command_id": 198, "duration": 0, "delay": 0},
+        {"device_id": 1, "command_id": 197, "duration": 2, "delay": 0},
+        {"device_id": 2, "command_id": 197, "duration": 0, "delay": 0},
+    ]
+    payload = build_macro_save_payload(
+        activity_id=101,
+        key_id=ButtonName.POWER_ON,
+        key_sequence=[
+            MacroKeyEntry(
+                device_id=s["device_id"],
+                key_id=s["command_id"],
+                fid=0,
+                duration=s["duration"],
+                delay=s["delay"],
+            )
+            for s in steps
+        ],
+        label="",
+        hub_version=HUB_VERSION_X1S,
+    )
+    assert payload[6] == 101
+    assert payload[7] == ButtonName.POWER_ON
+    assert payload[8] == len(steps)
+    for index, step in enumerate(steps):
+        row = payload[9 + index * 10 : 19 + index * 10]
+        assert row[0] == step["device_id"]
+        assert row[1] == step["command_id"]
+        assert row[8] == step["duration"]
+
+
+# ---------------------------------------------------------------------------
+# build_macro_save_payload: total_pages boundary (maintainer review point #1)
+# ---------------------------------------------------------------------------
+
+
+def _n_step_power_on_payload(n: int, *, hub_version: str = HUB_VERSION_X1S) -> bytes:
+    return build_macro_save_payload(
+        activity_id=101,
+        key_id=ButtonName.POWER_ON,
+        key_sequence=[
+            MacroKeyEntry(device_id=(i % 255) + 1, key_id=0xC6, fid=0, duration=0, delay=0xFF)
+            for i in range(n)
+        ],
+        label="POWER_ON",
+        hub_version=hub_version,
+    )
+
+
+def test_build_macro_save_payload_stays_single_page_at_eighteen_rows() -> None:
+    payload = _n_step_power_on_payload(18)
+    assert payload[4:6] == b"\x00\x01"
+
+
+def test_build_macro_save_payload_declares_two_pages_at_nineteen_rows() -> None:
+    """The maintainer's review point #1, as a direct regression test: a
+    macro save above 18 rows needs the paged write. ``build_macro_save_payload``
+    itself gets this right — it declares ``total_pages`` from the actual
+    body length — so the boundary sits exactly where the review said it
+    would. What the withdrawn services got wrong was downstream of this:
+    they handed this payload to a single ``execute_exchange`` frame instead
+    of ``_send_paged_macro_save``, so a 19+ step macro announced two pages
+    and delivered one. See
+    ``test_engine_macro_write_pages_a_nineteen_step_power_macro`` below and
+    ``tests/test_x1_proxy.py::test_build_paged_macro_save_payloads_matches_multiframe_shape``
+    / ``test_send_paged_macro_save_waits_for_each_chunk_ack`` for proof the
+    reused engine's sender does not repeat that mistake."""
+
+    payload = _n_step_power_on_payload(19)
+    assert payload[4:6] == b"\x00\x02"
+
+
+def test_build_macro_save_payload_page_boundary_holds_on_x1_too() -> None:
+    """X1's shorter (30-byte, vs. 60-byte on X1S/X2) label slot moves the
+    exact row count where the boundary sits (21/22 rather than 18/19) but
+    not the existence of a boundary — confirms it is a property of the
+    row count against the 247-byte page chunk on every hub version, not a
+    X1S/X2-only concern (the withdrawn ``set_power_macro``/
+    ``set_device_power_binding`` refused to run on X1 at all; the builder
+    itself never had that restriction)."""
+
+    below = _n_step_power_on_payload(21, hub_version=HUB_VERSION_X1)
+    above = _n_step_power_on_payload(22, hub_version=HUB_VERSION_X1)
+    assert below[4:6] == b"\x00\x01"
+    assert above[4:6] == b"\x00\x02"
+
+
+# ---------------------------------------------------------------------------
+# sync engine macro-save step: the reused engine pages a large power macro
+# ---------------------------------------------------------------------------
+
+
+def test_engine_macro_write_pages_a_nineteen_step_power_macro() -> None:
+    """``ActivitySyncMixin.sync_activity``'s macro_write step hands
+    ``_send_paged_macro_save`` a payload built the same way the builder
+    tests above verify — so a power macro that grows past the 18-row
+    boundary during an edit is paged correctly by construction, without
+    the sync engine needing any special casing for macro size."""
+
+    base = base_bundle()
+    edited = copy.deepcopy(base)
+    _activity(edited)["macros"][0]["steps"] = [
+        {"device_id": (i % 255) + 1, "command_id": 0xC6, "button_code": 0, "duration": 0, "delay": 255}
+        for i in range(19)
+    ]
+    proxy = FakeProxy(fresh_activity=_activity(base))
+
+    result = proxy.sync_activity(baseline=base, edited=edited, activity_id=ACTIVITY_ID)
+
+    assert result["status"] == "success"
+    macro_call = next(c for c in proxy.calls if c[0] == "macro_write")
+    button_id, payload = macro_call[1]
+    assert button_id == 198  # POWER_ON
+    assert payload[4:6] == b"\x00\x02"
+    assert payload[8] == 19

--- a/tests/test_sync_from_snapshot_service.py
+++ b/tests/test_sync_from_snapshot_service.py
@@ -1,0 +1,386 @@
+"""Service-handler tests for ``export_snapshot`` and ``sync_from_snapshot``.
+
+Style follows ``tests/test_roku_service_validation.py``: monkeypatch
+``_async_resolve_hub_from_call`` with a fake hub that records calls, then
+drive the ``_async_handle_*`` coroutine directly with a bare ``_FakeCall``.
+
+These two services are the script-callable counterpart of the live Control
+Panel editor's Activities/Hub tab (export) and its save action (sync) —
+see ``docs/protocol/write-flows.md`` and ``services.yaml`` for the design.
+``sync_from_snapshot`` shares its pre-write gauntlet and its engine entry
+point with the WS ``activity/sync``/``device/sync`` commands
+(``tests/test_activity_sync_ws.py``); the last test in this file proves
+that sharing is real code reuse, not parallel copies, by monkeypatching the
+shared helper and asserting both transports call through it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+integration = importlib.import_module("custom_components.sofabaton_x1s.__init__")
+
+from tests.test_activity_sync_ws import _bundle, _Conn, _device_bundle
+
+
+class _FakeCall:
+    def __init__(self, data: dict, hass=None):
+        self.data = data
+        self.hass = hass if hass is not None else SimpleNamespace(data={integration.DOMAIN: {}})
+
+
+class _FakeHub:
+    def __init__(self, *, version: str = "X1S", entry_id: str = "entry-1") -> None:
+        self.entry_id = entry_id
+        self.version = version
+        self.cache_generation = 3
+        self.calls: list[tuple[str, dict]] = []
+        self.structural_bundle: dict | None = None
+        self.sync_result: dict = {"status": "success", "completed_steps": 1, "total_steps": 1}
+
+    async def async_get_structural_bundle(self):
+        self.calls.append(("get_structural_bundle", {}))
+        return self.structural_bundle
+
+    async def async_sync_activity(self, *, baseline, edited, activity_id, progress_callback=None):
+        self.calls.append(
+            ("sync_activity", {"baseline": baseline, "edited": edited, "activity_id": activity_id})
+        )
+        return self.sync_result
+
+    async def async_sync_device(self, *, baseline, edited, device_id, progress_callback=None):
+        self.calls.append(
+            ("sync_device", {"baseline": baseline, "edited": edited, "device_id": device_id})
+        )
+        return self.sync_result
+
+    async def async_request_catalog(self, kind):
+        self.calls.append(("request_catalog", {"kind": kind}))
+
+    async def async_refresh_entity_structure(self, *, kind, ent_id):
+        self.calls.append(("refresh_entity_structure", {"kind": kind, "ent_id": ent_id}))
+
+
+def _wire_hub(monkeypatch, hub: _FakeHub | None = None) -> _FakeHub:
+    hub = hub if hub is not None else _FakeHub()
+
+    async def _resolve(_hass, _call):
+        return hub
+
+    monkeypatch.setattr(integration, "_async_resolve_hub_from_call", _resolve)
+    return hub
+
+
+def _wire_cache_store(monkeypatch, *, enabled: bool) -> None:
+    async def fake_store(_hass):
+        return SimpleNamespace(enabled=enabled)
+
+    monkeypatch.setattr(integration, "_async_get_persistent_cache_store", fake_store)
+
+
+# ---------------------------------------------------------------------------
+# export_snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_export_snapshot_requires_a_resolvable_hub(monkeypatch) -> None:
+    async def _resolve(_hass, _call):
+        return None
+
+    monkeypatch.setattr(integration, "_async_resolve_hub_from_call", _resolve)
+
+    with pytest.raises(ValueError, match="Could not resolve Sofabaton hub"):
+        asyncio.run(integration._async_handle_export_snapshot(_FakeCall({})))
+
+
+def test_export_snapshot_requires_persistent_cache_enabled(monkeypatch) -> None:
+    _wire_hub(monkeypatch)
+    _wire_cache_store(monkeypatch, enabled=False)
+
+    with pytest.raises(integration.HomeAssistantError, match="persistent cache"):
+        asyncio.run(integration._async_handle_export_snapshot(_FakeCall({})))
+
+
+def test_export_snapshot_requires_a_populated_cache(monkeypatch) -> None:
+    hub = _wire_hub(monkeypatch)
+    hub.structural_bundle = None
+    _wire_cache_store(monkeypatch, enabled=True)
+
+    with pytest.raises(integration.HomeAssistantError, match="No cached structural snapshot"):
+        asyncio.run(integration._async_handle_export_snapshot(_FakeCall({})))
+
+
+def test_export_snapshot_returns_cached_bundle_and_generation(monkeypatch) -> None:
+    hub = _wire_hub(monkeypatch)
+    hub.structural_bundle = _bundle([])
+    hub.cache_generation = 42
+    _wire_cache_store(monkeypatch, enabled=True)
+
+    result = asyncio.run(integration._async_handle_export_snapshot(_FakeCall({})))
+
+    assert result == {"bundle": hub.structural_bundle, "generation": 42}
+    assert hub.calls == [("get_structural_bundle", {})]
+
+
+# ---------------------------------------------------------------------------
+# sync_from_snapshot: field validation (before any hub write)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_from_snapshot_requires_a_resolvable_hub(monkeypatch) -> None:
+    async def _resolve(_hass, _call):
+        return None
+
+    monkeypatch.setattr(integration, "_async_resolve_hub_from_call", _resolve)
+
+    with pytest.raises(ValueError, match="Could not resolve Sofabaton hub"):
+        asyncio.run(
+            integration._async_handle_sync_from_snapshot(
+                _FakeCall({"entity_kind": "device", "entity_id": 1, "baseline": {}, "edited": {}})
+            )
+        )
+
+
+def test_sync_from_snapshot_requires_valid_entity_kind(monkeypatch) -> None:
+    _wire_hub(monkeypatch)
+
+    with pytest.raises(ValueError, match="entity_kind must be 'activity' or 'device'"):
+        asyncio.run(
+            integration._async_handle_sync_from_snapshot(
+                _FakeCall(
+                    {"entity_kind": "activity_group", "entity_id": 1, "baseline": {}, "edited": {}}
+                )
+            )
+        )
+
+
+def test_sync_from_snapshot_requires_dict_baseline_and_edited(monkeypatch) -> None:
+    _wire_hub(monkeypatch)
+
+    with pytest.raises(ValueError, match="baseline and edited must be hub_bundle objects"):
+        asyncio.run(
+            integration._async_handle_sync_from_snapshot(
+                _FakeCall({"entity_kind": "device", "entity_id": 1, "baseline": None, "edited": {}})
+            )
+        )
+
+
+def test_sync_from_snapshot_rejects_when_busy(monkeypatch) -> None:
+    hub = _wire_hub(monkeypatch)
+    registry = integration._BackupOperationRegistry(SimpleNamespace(loop=asyncio.new_event_loop()))
+    registry.create(kind="device_sync", entry_id=hub.entry_id, initial_state={"status": "running"})
+    call = _FakeCall(
+        {
+            "entity_kind": "device",
+            "entity_id": 1,
+            "baseline": _device_bundle([]),
+            "edited": _device_bundle([]),
+        },
+        hass=SimpleNamespace(data={integration.DOMAIN: {integration._BACKUP_OPERATIONS_KEY: registry}}),
+    )
+
+    with pytest.raises(integration.HomeAssistantError, match="already running"):
+        asyncio.run(integration._async_handle_sync_from_snapshot(call))
+
+    assert hub.calls == []
+
+
+def test_sync_from_snapshot_rejects_invalid_bundle_payload(monkeypatch) -> None:
+    _wire_hub(monkeypatch)
+    bad_baseline = _device_bundle([])
+    bad_baseline["schema_version"] = 99
+
+    with pytest.raises(integration.HomeAssistantError, match="schema_version"):
+        asyncio.run(
+            integration._async_handle_sync_from_snapshot(
+                _FakeCall(
+                    {
+                        "entity_kind": "device",
+                        "entity_id": 1,
+                        "baseline": bad_baseline,
+                        "edited": _device_bundle([]),
+                    }
+                )
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# sync_from_snapshot: drives the same engine entry point as the WS handler
+# ---------------------------------------------------------------------------
+
+
+def test_sync_from_snapshot_drives_hub_async_sync_device_and_returns_result(monkeypatch) -> None:
+    hub = _wire_hub(monkeypatch)
+    _wire_cache_store(monkeypatch, enabled=False)
+    baseline = _device_bundle([])
+    edited = _device_bundle([{"button_id": 0xB0, "device_id": 1, "command_id": 10}])
+
+    result = asyncio.run(
+        integration._async_handle_sync_from_snapshot(
+            _FakeCall(
+                {"entity_kind": "device", "entity_id": 1, "baseline": baseline, "edited": edited}
+            )
+        )
+    )
+
+    assert result == hub.sync_result
+    sync_calls = [c for c in hub.calls if c[0] == "sync_device"]
+    assert len(sync_calls) == 1
+    assert sync_calls[0][1]["device_id"] == 1
+    assert sync_calls[0][1]["baseline"] == baseline
+    assert sync_calls[0][1]["edited"] == edited
+    # Success tail runs the same post-sync cache refresh the WS path gets.
+    assert ("request_catalog", {"kind": "devices"}) in hub.calls
+    assert ("refresh_entity_structure", {"kind": "device", "ent_id": 1}) in hub.calls
+
+
+def test_sync_from_snapshot_drives_hub_async_sync_activity_for_activity_kind(monkeypatch) -> None:
+    hub = _wire_hub(monkeypatch)
+    _wire_cache_store(monkeypatch, enabled=False)
+    baseline = _bundle([])
+    edited = _bundle([{"button_id": 9, "device_id": 1, "command_id": 10, "name": "Fav"}])
+
+    result = asyncio.run(
+        integration._async_handle_sync_from_snapshot(
+            _FakeCall(
+                {"entity_kind": "activity", "entity_id": 101, "baseline": baseline, "edited": edited}
+            )
+        )
+    )
+
+    assert result == hub.sync_result
+    sync_calls = [c for c in hub.calls if c[0] == "sync_activity"]
+    assert len(sync_calls) == 1
+    assert sync_calls[0][1]["activity_id"] == 101
+
+
+def test_sync_from_snapshot_raises_when_engine_reports_failure(monkeypatch) -> None:
+    hub = _wire_hub(monkeypatch)
+    _wire_cache_store(monkeypatch, enabled=False)
+    hub.sync_result = {
+        "status": "failed",
+        "failed_at": "stale_check",
+        "message": "This device changed on the hub after you loaded it.",
+    }
+    baseline = _device_bundle([])
+    edited = _device_bundle([{"button_id": 0xB0, "device_id": 1, "command_id": 10}])
+
+    with pytest.raises(integration.HomeAssistantError, match="changed on the hub"):
+        asyncio.run(
+            integration._async_handle_sync_from_snapshot(
+                _FakeCall(
+                    {"entity_kind": "device", "entity_id": 1, "baseline": baseline, "edited": edited}
+                )
+            )
+        )
+
+
+def test_sync_from_snapshot_accepts_string_entity_id(monkeypatch) -> None:
+    """Service calls from YAML scripts commonly arrive as strings; every
+    other numeric field in this integration's services tolerates that.
+    entity_id goes through the same int() coercion _validate_entity_sync_inputs
+    already applies to activity_id/device_id from the WS payload."""
+
+    hub = _wire_hub(monkeypatch)
+    _wire_cache_store(monkeypatch, enabled=False)
+    baseline = _device_bundle([])
+    edited = _device_bundle([{"button_id": 0xB0, "device_id": 1, "command_id": 10}])
+
+    result = asyncio.run(
+        integration._async_handle_sync_from_snapshot(
+            _FakeCall(
+                {"entity_kind": "device", "entity_id": "1", "baseline": baseline, "edited": edited}
+            )
+        )
+    )
+
+    assert result == hub.sync_result
+
+
+# ---------------------------------------------------------------------------
+# WS and service both funnel through _async_prepare_entity_sync
+# ---------------------------------------------------------------------------
+
+
+def test_ws_and_service_share_the_prepare_entity_sync_helper(monkeypatch) -> None:
+    """Proves the refactor is real code sharing, not two parallel copies of
+    the busy/lock/validate/register logic: both the WS ``activity/sync``
+    command and the ``sync_from_snapshot`` service call through
+    ``_async_prepare_entity_sync``, and both hand its output to
+    ``_run_entity_sync_operation`` — the same engine entry point."""
+
+    prepare_calls: list[dict] = []
+    canned_baseline = _bundle([])
+    canned_edited = _bundle([{"button_id": 9, "device_id": 1, "command_id": 10, "name": "Fav"}])
+
+    async def fake_prepare(_hass, *, hub, entity_kind, sync_input, operation_label):
+        prepare_calls.append(
+            {
+                "hub": hub,
+                "entity_kind": entity_kind,
+                "operation_label": operation_label,
+                "activity_id": sync_input.get("activity_id"),
+            }
+        )
+        return f"op-{len(prepare_calls)}", canned_baseline, canned_edited, 101
+
+    monkeypatch.setattr(integration, "_async_prepare_entity_sync", fake_prepare)
+
+    hub = _wire_hub(monkeypatch)
+
+    async def fake_resolve_data(_hass, _data):
+        return hub
+
+    monkeypatch.setattr(integration, "_async_resolve_hub_from_data", fake_resolve_data)
+
+    # WS transport
+    conn = _Conn()
+    ws_hass = SimpleNamespace(
+        async_create_task=lambda coro: coro.close(),
+        data={integration.DOMAIN: {}},
+    )
+    asyncio.run(
+        integration._ws_activity_sync(
+            ws_hass,
+            conn,
+            {
+                "id": 1,
+                "entry_id": "entry-1",
+                "activity_id": 101,
+                "baseline": canned_baseline,
+                "edited": canned_edited,
+            },
+        )
+    )
+    assert conn.error is None
+    assert conn.result[1]["operation_id"] == "op-1"
+
+    # service transport
+    result = asyncio.run(
+        integration._async_handle_sync_from_snapshot(
+            _FakeCall(
+                {
+                    "entity_kind": "activity",
+                    "entity_id": 101,
+                    "baseline": canned_baseline,
+                    "edited": canned_edited,
+                }
+            )
+        )
+    )
+    assert result == hub.sync_result
+
+    assert len(prepare_calls) == 2
+    assert prepare_calls[0]["hub"] is hub
+    assert prepare_calls[1]["hub"] is hub
+    assert prepare_calls[0]["entity_kind"] == "activity"
+    assert prepare_calls[1]["entity_kind"] == "activity"
+    assert prepare_calls[0]["operation_label"] == "_ws_activity_sync"
+    assert prepare_calls[1]["operation_label"] == "sync_from_snapshot[activity]"
+    # Both transports fed _async_prepare_entity_sync the same activity_id.
+    assert prepare_calls[0]["activity_id"] == 101

--- a/tests/test_sync_from_snapshot_service.py
+++ b/tests/test_sync_from_snapshot_service.py
@@ -210,6 +210,96 @@ def test_sync_from_snapshot_rejects_invalid_bundle_payload(monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# sync_from_snapshot: expected_generation baseline-freshness guard
+# ---------------------------------------------------------------------------
+
+
+def _sync_call_data(**extra) -> dict:
+    return {
+        "entity_kind": "device",
+        "entity_id": 1,
+        "baseline": _device_bundle([]),
+        "edited": _device_bundle([{"button_id": 0xB0, "device_id": 1, "command_id": 10}]),
+        **extra,
+    }
+
+
+def test_sync_from_snapshot_omitted_expected_generation_skips_the_guard(monkeypatch) -> None:
+    hub = _wire_hub(monkeypatch)
+    _wire_cache_store(monkeypatch, enabled=False)
+    hub.cache_generation = 999  # would mismatch anything; must not matter
+
+    result = asyncio.run(
+        integration._async_handle_sync_from_snapshot(_FakeCall(_sync_call_data()))
+    )
+
+    assert result == hub.sync_result
+    assert any(c[0] == "sync_device" for c in hub.calls)
+
+
+def test_sync_from_snapshot_matching_expected_generation_proceeds(monkeypatch) -> None:
+    hub = _wire_hub(monkeypatch)
+    _wire_cache_store(monkeypatch, enabled=False)
+    hub.cache_generation = 41
+
+    result = asyncio.run(
+        integration._async_handle_sync_from_snapshot(
+            _FakeCall(_sync_call_data(expected_generation=41))
+        )
+    )
+    assert result == hub.sync_result
+    assert any(c[0] == "sync_device" for c in hub.calls)
+
+    # YAML script calls commonly stringify numbers; "41" must coerce.
+    hub.calls = []
+    result = asyncio.run(
+        integration._async_handle_sync_from_snapshot(
+            _FakeCall(_sync_call_data(expected_generation="41"))
+        )
+    )
+    assert result == hub.sync_result
+    assert any(c[0] == "sync_device" for c in hub.calls)
+
+
+def test_sync_from_snapshot_stale_expected_generation_refuses_loudly(monkeypatch) -> None:
+    """A moved cache generation refuses before any write AND before the
+    operation registry gets an entry — a stale request must not consume an
+    operation slot other callers would then see as busy."""
+
+    hub = _wire_hub(monkeypatch)
+    hub.cache_generation = 44
+    registry = integration._BackupOperationRegistry(SimpleNamespace(loop=asyncio.new_event_loop()))
+    call = _FakeCall(
+        _sync_call_data(expected_generation=41),
+        hass=SimpleNamespace(
+            data={integration.DOMAIN: {integration._BACKUP_OPERATIONS_KEY: registry}}
+        ),
+    )
+
+    with pytest.raises(
+        integration.HomeAssistantError,
+        match="expected generation 41, hub cache is at 44",
+    ):
+        asyncio.run(integration._async_handle_sync_from_snapshot(call))
+
+    assert hub.calls == []
+    assert registry.latest_for_entry(hub.entry_id, kind="device_sync") is None
+
+
+def test_sync_from_snapshot_rejects_non_integer_expected_generation(monkeypatch) -> None:
+    hub = _wire_hub(monkeypatch)
+
+    with pytest.raises(ValueError, match="expected_generation must be an integer"):
+        asyncio.run(
+            integration._async_handle_sync_from_snapshot(
+                _FakeCall(_sync_call_data(expected_generation="not-a-number"))
+            )
+        )
+
+    assert hub.calls == []
+
+
+# ---------------------------------------------------------------------------
 # sync_from_snapshot: drives the same engine entry point as the WS handler
 # ---------------------------------------------------------------------------
 
@@ -318,13 +408,16 @@ def test_ws_and_service_share_the_prepare_entity_sync_helper(monkeypatch) -> Non
     canned_baseline = _bundle([])
     canned_edited = _bundle([{"button_id": 9, "device_id": 1, "command_id": 10, "name": "Fav"}])
 
-    async def fake_prepare(_hass, *, hub, entity_kind, sync_input, operation_label):
+    async def fake_prepare(
+        _hass, *, hub, entity_kind, sync_input, operation_label, expected_generation=None
+    ):
         prepare_calls.append(
             {
                 "hub": hub,
                 "entity_kind": entity_kind,
                 "operation_label": operation_label,
                 "activity_id": sync_input.get("activity_id"),
+                "expected_generation": expected_generation,
             }
         )
         return f"op-{len(prepare_calls)}", canned_baseline, canned_edited, 101
@@ -384,3 +477,7 @@ def test_ws_and_service_share_the_prepare_entity_sync_helper(monkeypatch) -> Non
     assert prepare_calls[1]["operation_label"] == "sync_from_snapshot[activity]"
     # Both transports fed _async_prepare_entity_sync the same activity_id.
     assert prepare_calls[0]["activity_id"] == 101
+    # Neither transport engaged the freshness guard here: the WS path never
+    # sends an expected generation, and this service call omitted it.
+    assert prepare_calls[0]["expected_generation"] is None
+    assert prepare_calls[1]["expected_generation"] is None


### PR DESCRIPTION
Follow-up to #262, opened fresh against dev as requested (that one can close as superseded). Full context and discussion are over there.

What's here beyond what we discussed:

* `export_snapshot` returns `{bundle, generation}`. It already matched the WS shape; the services.yaml description now actually says so.
* `sync_from_snapshot` takes an optional `expected_generation` and refuses a stale baseline loudly, before it consumes an operation slot: "stale baseline: expected generation 41, hub cache is at 44 - re-export the snapshot". The check sits in the shared prep helper after the busy guard, in an await-free stretch, so it can't race another sync's generation bump. Mismatch is `!=` rather than `<` so a generation reset after a reload gets caught too. The WS path passes nothing and skips the check, since the editor rebases its baseline after every sync anyway.
* Tests for omitted, matching, stale, and non-integer generation, on top of the earlier service and row tests. 1398 passing here; the tools-card frontend test wants `npm ci` and fails the same on clean dev.

Raw-slot before/after check on my X1S coming as a comment on this PR once I've run it.
