### PR TITLE
Fix activity refresh timeouts triggering false power-off events

### DIFF
--- a/.github/workflows/sofabaton-x-ci.yml
+++ b/.github/workflows/sofabaton-x-ci.yml
@@ -5,6 +5,7 @@
 name: sofabaton-x CI
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "custom_components/sofabaton_x1s/lib/**"

--- a/custom_components/sofabaton_x1s/__init__.py
+++ b/custom_components/sofabaton_x1s/__init__.py
@@ -3823,7 +3823,11 @@ async def _ws_refresh_catalog(hass: HomeAssistant, connection, msg: dict[str, An
         connection.send_error(msg["id"], "unavailable", str(err))
         return
 
-    await hub.async_request_catalog(msg["kind"])
+    try:
+        await hub.async_request_catalog(msg["kind"])
+    except TimeoutError as err:
+        connection.send_error(msg["id"], "timeout", str(err))
+        return
     store = await _async_get_persistent_cache_store(hass)
     if store.enabled:
         payload = await hub.async_export_cache_state()

--- a/custom_components/sofabaton_x1s/hub.py
+++ b/custom_components/sofabaton_x1s/hub.py
@@ -83,7 +83,7 @@ from .lib.wifi_inplace_plan import (
     derive_device_level_bindings,
     desired_snapshot_from_config,
 )
-from .lib.x1_proxy import X1Proxy
+from .lib.x1_proxy import X1Proxy, to_export_view
 from .command_config import (
     COMMAND_BRAND_PREFIX,
     LEGACY_COMMAND_BRAND_PREFIX,
@@ -263,6 +263,7 @@ class SofabatonHub:
         self._ota_pause_seconds: float = 300.0
         self._devices_generation: int = 0
         self._activities_generation: int = 0
+        self._received_activity_snapshot: tuple[X1Proxy, int, dict[int, dict[str, Any]]] | None = None
         self._cache_generation: int = 0
         self.proxy_enabled: bool = proxy_enabled
         self.hex_logging_enabled: bool = hex_logging_enabled
@@ -619,7 +620,7 @@ class SofabatonHub:
 
         proxy.on_activity_change(self._on_activity_change)
         proxy.on_activity_list_update(self._on_activity_list_update)
-        proxy.on_burst_end("activities", self._on_activities_burst)
+        proxy.on_burst_end("activities", partial(self._on_activities_burst, proxy=proxy))
         proxy.on_burst_end("buttons", self._on_buttons_burst)
         proxy.on_client_state_change(self._on_client_state_change)
         proxy.on_hub_state_change(self._on_hub_state_change)
@@ -823,7 +824,7 @@ class SofabatonHub:
             return None
         return dict(self._last_hub_event)
 
-    async def _async_prune_activity_event_actions(self) -> None:
+    async def _async_prune_activity_event_actions(self, activity_ids: list[int]) -> None:
         """Drop per-activity event actions for ids no longer on the hub.
 
         Runs after an authoritative activity-catalog refresh so persistent
@@ -833,7 +834,7 @@ class SofabatonHub:
         try:
             store = await async_get_command_config_store(self.hass)
             await store.async_prune_activity_event_actions(
-                self.entry_id, list(self.activities.keys())
+                self.entry_id, activity_ids
             )
         except Exception:  # noqa: BLE001 - housekeeping must never break sync
             self._log.warning(
@@ -863,15 +864,23 @@ class SofabatonHub:
         except TypeError:
             return self._proxy.get_activities()
 
-    def _on_activities_burst(self, key: str) -> None:
-        if not self._proxy._last_activities_burst_complete:
+    def _on_activities_burst(self, key: str, *, proxy: X1Proxy | None = None) -> None:
+        proxy = self._proxy if proxy is None else proxy
+        if not proxy._last_activities_burst_complete:
             return
         # Capture this burst before crossing into the HA event loop; a later
         # burst can finish before _inner runs. Cached readiness alone cannot
         # establish that the current refresh succeeded.
-        acts, ready = self._get_activities_cached()
+        generation, snapshot = proxy._committed_activity_snapshot
+        acts = {act_id: to_export_view(row) for act_id, row in snapshot.items()}
+        ready = True
 
         def _inner() -> None:
+            received = self._received_activity_snapshot
+            if proxy is not self._proxy or (
+                received is not None and received[0] is proxy and received[1] > generation
+            ):
+                return
             self._log.debug(
                 "[%s] on_burst_end('activities'): ready=%s, count=%s",
                 self.entry_id,
@@ -891,6 +900,7 @@ class SofabatonHub:
                 self._hub_event_hooks_armed = True
             if ready:
                 activities_changed = self._replace_activities(acts)
+                self._received_activity_snapshot = (proxy, generation, snapshot)
                 self._activities_generation += 1
                 if activities_changed:
                     self._bump_cache_generation()
@@ -900,7 +910,7 @@ class SofabatonHub:
                         # Skipped on an empty catalog so a transient empty read
                         # can never wipe the whole configuration.
                         self.hass.async_create_task(
-                            self._async_prune_activity_event_actions()
+                            self._async_prune_activity_event_actions(list(acts))
                         )
                 self._sync_current_activity_from_cache(clear_when_unknown=True)
             async_dispatcher_send(self.hass, signal_activity(self.entry_id))
@@ -3552,35 +3562,40 @@ class SofabatonHub:
         complete snapshot arrives; the last committed catalog stays usable.
         """
 
-        previous_generation = self._activities_generation
-        previous_snapshot = self._proxy._activities_snapshot_generation
-        await self.hass.async_add_executor_job(self._proxy.request_activities)
+        proxy = self._proxy
+        previous_snapshot = proxy._activities_snapshot_generation
+        await self.hass.async_add_executor_job(proxy.request_activities)
 
         deadline = monotonic() + timeout_seconds
-        # A prior commit may still have its HA callback queued when this
-        # request starts. Require a new proxy commit as well as HA delivery.
-        while (
-            self._proxy._activities_snapshot_generation <= previous_snapshot
-            or self._activities_generation <= previous_generation
-        ):
+        # The acknowledgment carries its source, generation and raw contents.
+        # Independent counters can pair an old HA callback with a new proxy
+        # commit whose callback has not been delivered yet.
+        while True:
+            if proxy is not self._proxy:
+                raise TimeoutError("Hub proxy changed while refreshing the activities catalog")
+            received = self._received_activity_snapshot
+            if received is not None and received[0] is proxy and received[1] > previous_snapshot:
+                return {act_id: dict(row) for act_id, row in received[2].items()}
             remaining = deadline - monotonic()
             if remaining <= 0:
                 raise TimeoutError("Timed out waiting for a complete activities catalog from the hub")
             await asyncio.sleep(min(0.1, remaining))
 
-        return dict(self._proxy.state.entities("activity"))
-
-    async def async_request_catalog(self, kind: str, timeout_seconds: float = 30.0) -> None:
+    async def async_request_catalog(
+        self, kind: str, timeout_seconds: float = 30.0
+    ) -> dict[int, dict[str, Any]] | None:
         """Send REQ_ACTIVITIES or REQ_DEVICES to the hub and wait for the burst to complete.
 
         Activity refreshes preserve the last committed catalog and active state
         until a complete replacement arrives. Per-entity detail data is pruned
         only after a successful refresh confirms an entity was removed.
+        Activity requests return the acknowledged raw snapshot so subsequent
+        validation uses the same catalog as the successful refresh.
         """
         if kind == "activities":
             old_ids = await self.hass.async_add_executor_job(self._proxy.get_known_activity_ids)
-            await self._async_refresh_activities_snapshot(timeout_seconds=timeout_seconds)
-            new_ids = await self.hass.async_add_executor_job(self._proxy.get_known_activity_ids)
+            snapshot = await self._async_refresh_activities_snapshot(timeout_seconds=timeout_seconds)
+            new_ids = set(snapshot)
             cached_detail_ids = await self.hass.async_add_executor_job(
                 self._proxy.get_cached_activity_detail_ids
             )
@@ -3605,6 +3620,7 @@ class SofabatonHub:
             async_dispatcher_send(self.hass, signal_activity(self.entry_id))
             async_dispatcher_send(self.hass, signal_commands(self.entry_id))
             async_dispatcher_send(self.hass, signal_macros(self.entry_id))
+            return snapshot
         else:
             async_dispatcher_send(self.hass, signal_devices(self.entry_id))
             async_dispatcher_send(self.hass, signal_commands(self.entry_id))
@@ -4564,12 +4580,14 @@ class SofabatonHub:
                         message="Validating Activities against the hub",
                     )
                     try:
-                        await self.async_request_catalog("activities")
+                        activity_snapshot = await self.async_request_catalog("activities")
                     except TimeoutError as err:
                         raise HomeAssistantError(
                             "Failed to refresh the Activity list from the hub; "
                             "sync aborted rather than deploying against a stale catalog"
                         ) from err
+                    if activity_snapshot is None:
+                        raise HomeAssistantError("Failed to receive the refreshed Activity snapshot")
                     stored_activity_labels = command_payload.get("activity_labels")
                     if isinstance(stored_activity_labels, dict):
                         label_mismatches: list[str] = []
@@ -4579,7 +4597,7 @@ class SofabatonHub:
                             ).strip()
                             if not stored_label:
                                 continue
-                            entry = self.activities.get(act_id)
+                            entry = activity_snapshot.get(act_id)
                             if entry is None:
                                 # Deleted activities are dropped from the
                                 # deploy further down, matching the existing

--- a/custom_components/sofabaton_x1s/hub.py
+++ b/custom_components/sofabaton_x1s/hub.py
@@ -864,8 +864,14 @@ class SofabatonHub:
             return self._proxy.get_activities()
 
     def _on_activities_burst(self, key: str) -> None:
+        if not self._proxy._last_activities_burst_complete:
+            return
+        # Capture this burst before crossing into the HA event loop; a later
+        # burst can finish before _inner runs. Cached readiness alone cannot
+        # establish that the current refresh succeeded.
+        acts, ready = self._get_activities_cached()
+
         def _inner() -> None:
-            acts, ready = self._get_activities_cached()
             self._log.debug(
                 "[%s] on_burst_end('activities'): ready=%s, count=%s",
                 self.entry_id,
@@ -3542,38 +3548,38 @@ class SofabatonHub:
 
         Returns the raw ``state.entities("activity")`` view (``raw_body``
         included); the JSON-export boundary is the only place that
-        strips it via :func:`to_export_view`.
+        strips it via :func:`to_export_view`. Raises ``TimeoutError`` if no
+        complete snapshot arrives; the last committed catalog stays usable.
         """
 
         previous_generation = self._activities_generation
+        previous_snapshot = self._proxy._activities_snapshot_generation
         await self.hass.async_add_executor_job(self._proxy.request_activities)
 
         deadline = monotonic() + timeout_seconds
-        while monotonic() < deadline:
-            if self._activities_generation > previous_generation:
-                return dict(self._proxy.state.entities("activity"))
-            await asyncio.sleep(0.1)
+        # A prior commit may still have its HA callback queued when this
+        # request starts. Require a new proxy commit as well as HA delivery.
+        while (
+            self._proxy._activities_snapshot_generation <= previous_snapshot
+            or self._activities_generation <= previous_generation
+        ):
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                raise TimeoutError("Timed out waiting for a complete activities catalog from the hub")
+            await asyncio.sleep(min(0.1, remaining))
 
         return dict(self._proxy.state.entities("activity"))
 
     async def async_request_catalog(self, kind: str, timeout_seconds: float = 30.0) -> None:
         """Send REQ_ACTIVITIES or REQ_DEVICES to the hub and wait for the burst to complete.
 
-        Uses a snapshot-clear-fetch-prune strategy: the name catalog is cleared before
-        the request so deleted entries don't persist, and per-entity detail data
-        (commands, macros) is preserved for entities that still exist and pruned only
-        for entities that were removed from the catalog.
+        Activity refreshes preserve the last committed catalog and active state
+        until a complete replacement arrives. Per-entity detail data is pruned
+        only after a successful refresh confirms an entity was removed.
         """
         if kind == "activities":
             old_ids = await self.hass.async_add_executor_job(self._proxy.get_known_activity_ids)
-            await self.hass.async_add_executor_job(self._proxy.clear_activities_catalog)
-            previous_generation = self._activities_generation
-            await self.hass.async_add_executor_job(self._proxy.request_activities)
-            deadline = monotonic() + timeout_seconds
-            while monotonic() < deadline:
-                if self._activities_generation > previous_generation:
-                    break
-                await asyncio.sleep(0.1)
+            await self._async_refresh_activities_snapshot(timeout_seconds=timeout_seconds)
             new_ids = await self.hass.async_add_executor_job(self._proxy.get_known_activity_ids)
             cached_detail_ids = await self.hass.async_add_executor_job(
                 self._proxy.get_cached_activity_detail_ids

--- a/custom_components/sofabaton_x1s/hub.py
+++ b/custom_components/sofabaton_x1s/hub.py
@@ -4563,13 +4563,13 @@ class SofabatonHub:
                         phase="validating_activities",
                         message="Validating Activities against the hub",
                     )
-                    previous_activities_generation = self._activities_generation
-                    await self.async_request_catalog("activities")
-                    if self._activities_generation == previous_activities_generation:
+                    try:
+                        await self.async_request_catalog("activities")
+                    except TimeoutError as err:
                         raise HomeAssistantError(
                             "Failed to refresh the Activity list from the hub; "
                             "sync aborted rather than deploying against a stale catalog"
-                        )
+                        ) from err
                     stored_activity_labels = command_payload.get("activity_labels")
                     if isinstance(stored_activity_labels, dict):
                         label_mismatches: list[str] = []

--- a/custom_components/sofabaton_x1s/lib/opcode_handlers.py
+++ b/custom_components/sofabaton_x1s/lib/opcode_handlers.py
@@ -682,6 +682,7 @@ class AckReadyHandler(BaseFrameHandler):
         externally_applied = proxy.notify_hub_ready()
         if proxy.can_issue_commands():
             proxy._log.info("[HINT] no proxy client; auto-REQ_ACTIVITIES")
+            on_send = None
             if (
                 proxy.state.current_activity is None
                 and proxy._activities_catalog_ready
@@ -690,12 +691,16 @@ class AckReadyHandler(BaseFrameHandler):
                 # Known powered off (not merely state-not-yet-fetched). If the
                 # refreshed state stays off, this ACK_READY was an OFF press
                 # with nothing left to turn off.
-                proxy.flag_pending_redundant_off_check()
-            if proxy.enqueue_cmd(OP_REQ_ACTIVITIES, expects_burst=True, burst_kind="activities"):
+                on_send = proxy.flag_pending_redundant_off_check()
+            if proxy.enqueue_cmd(
+                OP_REQ_ACTIVITIES, expects_burst=True, burst_kind="activities", on_send=on_send
+            ):
                 # An MQTT push for this same transition may still be on
                 # its way; until the burst lands it must not arm a settle
                 # gate that no later ACK_READY would release.
                 proxy.note_ack_ready_refresh()
+            else:
+                proxy.clear_pending_redundant_off_check()
             if proxy.state.current_activity_hint is not None:
                 ent_lo = proxy.state.current_activity_hint & 0xFF
 

--- a/custom_components/sofabaton_x1s/lib/proxy_backup.py
+++ b/custom_components/sofabaton_x1s/lib/proxy_backup.py
@@ -546,7 +546,10 @@ class CacheBackupMixin:
         self._devices_catalog_ready = False
 
     def clear_activities_catalog(self) -> None:
-        """Clear only the activity name catalog before a fresh activity list fetch.
+        """Explicitly invalidate the activity catalog, for example after an erase.
+
+        Ordinary refreshes must preserve the committed catalog and active hint
+        until a complete replacement arrives; do not clear them before a read.
 
         Deliberately does NOT clear per-activity keymaps, favorites, keybindings,
         or macros — those are not returned by OP_REQ_ACTIVITIES and would not be

--- a/custom_components/sofabaton_x1s/lib/proxy_catalog.py
+++ b/custom_components/sofabaton_x1s/lib/proxy_catalog.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 
 import threading
 import time
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Callable
 
 from .hub_versions import HUB_VERSION_X2
 from .commands import extract_ir_dump_blob, extract_ir_dump_label_field
@@ -34,6 +35,15 @@ from .state_helpers import normalize_device_entry
 
 
 ACTIVITY_INCOMPLETE_RETRY_DELAY_S = 0.75
+# Allow a read and the X2 retry, while bounding intent behind queued traffic.
+REDUNDANT_OFF_CONFIRM_TIMEOUT_S = 15.0
+
+
+@dataclass
+class RedundantOffConfirmation:
+    deadline: float
+    request_generation: int | None = None
+    retry_pending: bool = False
 
 
 def _to_export_view():
@@ -357,10 +367,57 @@ class CatalogMixin:
     def _begin_activity_request(self, *, is_retry: bool = False) -> None:
         self._activity_request_serial += 1
         self._activity_request_inflight = self._activity_request_serial
+        pending = self._pending_redundant_off_check
+        if pending is not None and pending.retry_pending:
+            if is_retry:
+                pending.request_generation = self._activity_request_serial
+                pending.retry_pending = False
+            else:
+                self.clear_pending_redundant_off_check()
         self._activity_retry_due_at = None
         if not is_retry:
             self._activity_retry_count = 0
         self._reset_pending_activity_snapshot(self._activity_request_inflight)
+
+    def flag_pending_redundant_off_check(self) -> Callable[[], None]:
+        """Return the send hook binding this press to its confirmation request."""
+        pending = RedundantOffConfirmation(time.monotonic() + REDUNDANT_OFF_CONFIRM_TIMEOUT_S)
+        self._pending_redundant_off_check = pending
+
+        def bind_request() -> None:
+            if self._pending_redundant_off_check is pending:
+                if time.monotonic() >= pending.deadline:
+                    self.clear_pending_redundant_off_check()
+                else:
+                    # The scheduler invokes this only when this exact queued
+                    # command is about to call _begin_activity_request.
+                    pending.request_generation = self._activity_request_serial + 1
+
+        return bind_request
+
+    def clear_pending_redundant_off_check(self) -> None:
+        self._pending_redundant_off_check = None
+
+    def _consume_pending_redundant_off_check(self, trigger: str) -> bool:
+        pending = self._pending_redundant_off_check
+        if pending is None:
+            return False
+        if trigger != "activities" or time.monotonic() >= pending.deadline:
+            self.clear_pending_redundant_off_check()
+            return False
+        if (
+            pending.request_generation is None
+            or pending.request_generation != self._last_activities_request_generation
+        ):
+            return False
+        if not self._last_activities_burst_complete:
+            if self._activity_retry_due_at is None:
+                self.clear_pending_redundant_off_check()
+            else:
+                pending.retry_pending = True
+            return False
+        self.clear_pending_redundant_off_check()
+        return True
 
     def _schedule_activity_retry(self, *, now: float | None = None) -> None:
         if self.hub_version != HUB_VERSION_X2:
@@ -740,6 +797,7 @@ class CatalogMixin:
 
     def _on_activities_burst_end(self, key: str) -> None:
         generation = self._activity_request_inflight
+        self._last_activities_request_generation = generation
         complete = generation is not None and self._activity_pending_generation == generation and self._activity_snapshot_complete()
         # Cache readiness describes the last good catalog, not this burst.
         # Later listeners must distinguish a fresh commit from a timeout.
@@ -748,6 +806,12 @@ class CatalogMixin:
         if complete:
             self._commit_pending_activity_snapshot()
             self._activities_snapshot_generation += 1
+            # Publish generation and contents together. HA must acknowledge
+            # this exact snapshot, even if other commits precede its callback.
+            self._committed_activity_snapshot = (
+                self._activities_snapshot_generation,
+                {act_id: dict(row) for act_id, row in self.state.entities("activity").items()},
+            )
             self._log.info(
                 "[ACT] committed complete activities snapshot rows=%d request=%s",
                 len(self._activity_pending_rows),

--- a/custom_components/sofabaton_x1s/lib/proxy_catalog.py
+++ b/custom_components/sofabaton_x1s/lib/proxy_catalog.py
@@ -741,9 +741,13 @@ class CatalogMixin:
     def _on_activities_burst_end(self, key: str) -> None:
         generation = self._activity_request_inflight
         complete = generation is not None and self._activity_pending_generation == generation and self._activity_snapshot_complete()
+        # Cache readiness describes the last good catalog, not this burst.
+        # Later listeners must distinguish a fresh commit from a timeout.
+        self._last_activities_burst_complete = complete
 
         if complete:
             self._commit_pending_activity_snapshot()
+            self._activities_snapshot_generation += 1
             self._log.info(
                 "[ACT] committed complete activities snapshot rows=%d request=%s",
                 len(self._activity_pending_rows),

--- a/custom_components/sofabaton_x1s/lib/state_helpers.py
+++ b/custom_components/sofabaton_x1s/lib/state_helpers.py
@@ -634,7 +634,7 @@ class BurstScheduler:
         self.active = False
         self.kind: str | None = None
         self.last_ts = 0.0
-        self.queue: list[tuple[int, bytes, bool, Optional[str]]] = []
+        self.queue: list[tuple[int, bytes, bool, Optional[str], Optional[Callable[[], None]]]] = []
         self.listeners: dict[str, list[Callable[[str], None]]] = {}
 
     def on_burst_end(self, key: str, cb: Callable[[str], None]) -> None:
@@ -655,6 +655,7 @@ class BurstScheduler:
         burst_kind: Optional[str],
         can_issue: Callable[[], bool],
         sender: Callable[[int, bytes], None],
+        on_send: Optional[Callable[[], None]] = None,
         now: Optional[float] = None,
     ) -> bool:
         is_burst = expects_burst
@@ -664,12 +665,14 @@ class BurstScheduler:
             return False
 
         if self.active:
-            self.queue.append((opcode, payload, is_burst, burst_kind))
+            self.queue.append((opcode, payload, is_burst, burst_kind, on_send))
             return True
 
         if is_burst:
             self.start(burst_kind or "generic", now=current_time)
 
+        if on_send is not None:
+            on_send()
         sender(opcode, payload)
         return True
 
@@ -723,11 +726,13 @@ class BurstScheduler:
         self._notify_burst_end(finished_kind)
 
         while self.queue:
-            op, payload, is_burst, next_kind = self.queue.pop(0)
+            op, payload, is_burst, next_kind, on_send = self.queue.pop(0)
             if not can_issue():
                 continue
             if is_burst:
                 self.start(next_kind or "generic", now=now)
+            if on_send is not None:
+                on_send()
             sender(op, payload)
             if self.active:
                 break
@@ -739,4 +744,3 @@ class BurstScheduler:
             prefix = key.split(":", 1)[0]
             for cb in self.listeners.get(prefix, []):
                 cb(key)
-

--- a/custom_components/sofabaton_x1s/lib/x1_proxy.py
+++ b/custom_components/sofabaton_x1s/lib/x1_proxy.py
@@ -169,7 +169,7 @@ from .proxy_backup_export import BackupExportMixin
 from .proxy_activity_ops import ActivityOpsMixin
 from .proxy_activity_sync import ActivitySyncMixin
 from .proxy_ack_waiters import AckWaitersMixin
-from .proxy_catalog import CatalogMixin
+from .proxy_catalog import CatalogMixin, RedundantOffConfirmation
 from .proxy_exchange import ExchangeMixin
 from .proxy_frame_decode import FrameDecodeMixin, _hexdump
 from .proxy_ir_blob import IrBlobMixin
@@ -466,7 +466,9 @@ class X1Proxy(FrameDecodeMixin, IrBlobMixin, CatalogMixin, ExchangeMixin, AckWai
         self._activity_request_inflight: int | None = None
         self._activities_catalog_ready = False
         self._last_activities_burst_complete = False
+        self._last_activities_request_generation: int | None = None
         self._activities_snapshot_generation = 0
+        self._committed_activity_snapshot: tuple[int, dict[int, dict[str, Any]]] = (0, {})
         self._activity_retry_count = 0
         self._activity_retry_due_at: float | None = None
         self._activity_retry_send_pending = False
@@ -487,7 +489,7 @@ class X1Proxy(FrameDecodeMixin, IrBlobMixin, CatalogMixin, ExchangeMixin, AckWai
         # Set when ACK_READY arrives while the hub is already powered off;
         # resolved by the next active-state evaluation (see
         # handle_active_state). A no-op OFF press is the only known trigger.
-        self._pending_redundant_off_check = False
+        self._pending_redundant_off_check: RedundantOffConfirmation | None = None
         self._app_devices_deadline: float | None = None
         self._app_devices_retry_sent = False
         self._pending_virtual: dict[str, Any] | None = None
@@ -670,6 +672,7 @@ class X1Proxy(FrameDecodeMixin, IrBlobMixin, CatalogMixin, ExchangeMixin, AckWai
             cb()
 
     def handle_active_state(self, trigger: str) -> None:
+        pending_redundant_off = self._consume_pending_redundant_off_check(trigger)
         if trigger == "activities":
             # The ACK refresh is no longer in flight, even on timeout. A
             # later external transition must arm its own settling gate.
@@ -679,8 +682,6 @@ class X1Proxy(FrameDecodeMixin, IrBlobMixin, CatalogMixin, ExchangeMixin, AckWai
             if not self._last_activities_burst_complete:
                 return
         new_id, old_id = self.state.update_activity_state()
-        pending_redundant_off = self._pending_redundant_off_check
-        self._pending_redundant_off_check = False
         if new_id != old_id:
             if new_id is not None:
                 self._notify_activity_change(new_id & 0xFF, old_id & 0xFF if old_id is not None else None)
@@ -692,15 +693,6 @@ class X1Proxy(FrameDecodeMixin, IrBlobMixin, CatalogMixin, ExchangeMixin, AckWai
             # is an OFF press on the remote while everything was already off.
             self._log.info("[HINT] OFF pressed while hub already powered off")
             self._notify_redundant_off_press()
-
-    def flag_pending_redundant_off_check(self) -> None:
-        """Arm the redundant-OFF check for the next active-state evaluation.
-
-        Called when ACK_READY arrives while the cached state says the hub is
-        already powered off (see :class:`AckReadyHandler`).
-        """
-
-        self._pending_redundant_off_check = True
 
     def apply_external_activity_state(self, activity_id: int | None) -> bool:
         """Apply an activity change learned outside the TCP session.
@@ -860,6 +852,7 @@ class X1Proxy(FrameDecodeMixin, IrBlobMixin, CatalogMixin, ExchangeMixin, AckWai
         *,
         expects_burst: bool = False,
         burst_kind: str | None = None,
+        on_send: Callable[[], None] | None = None,
     ) -> bool:
         sent = self._burst.queue_or_send(
             opcode=opcode,
@@ -868,6 +861,7 @@ class X1Proxy(FrameDecodeMixin, IrBlobMixin, CatalogMixin, ExchangeMixin, AckWai
             burst_kind=burst_kind,
             can_issue=self.can_issue_commands,
             sender=self._send_cmd_frame,
+            on_send=on_send,
         )
         if sent:
             self._log.debug("%s queued %s (0x%04X) %dB", LogTag.CMD, OPNAMES.get(opcode, f"OP_{opcode:04X}"), opcode, len(payload))
@@ -1770,6 +1764,7 @@ class X1Proxy(FrameDecodeMixin, IrBlobMixin, CatalogMixin, ExchangeMixin, AckWai
             # commands sit out the settle timeout for nothing.
             self._external_settle_event.set()
             self._ack_ready_refresh_pending = False
+            self.clear_pending_redundant_off_check()
         for cb in self._hub_state_listeners:
             try:
                 cb(connected)
@@ -1895,6 +1890,9 @@ class X1Proxy(FrameDecodeMixin, IrBlobMixin, CatalogMixin, ExchangeMixin, AckWai
             self._button_burst_expected_frames.clear()
 
     def _handle_idle(self, now: float) -> None:
+        pending = self._pending_redundant_off_check
+        if pending is not None and now >= pending.deadline:
+            self.clear_pending_redundant_off_check()
         if self._frame_thread_ident is None:
             # The transport bridge invokes this callback on its
             # frame-processing thread; latch its ident so exchange()

--- a/custom_components/sofabaton_x1s/lib/x1_proxy.py
+++ b/custom_components/sofabaton_x1s/lib/x1_proxy.py
@@ -671,11 +671,13 @@ class X1Proxy(FrameDecodeMixin, IrBlobMixin, CatalogMixin, ExchangeMixin, AckWai
 
     def handle_active_state(self, trigger: str) -> None:
         if trigger == "activities":
+            # The ACK refresh is no longer in flight, even on timeout. A
+            # later external transition must arm its own settling gate.
+            self._ack_ready_refresh_pending = False
             # A scheduler timeout also ends a burst. Only a committed
             # snapshot can confirm a state change or a redundant OFF press.
             if not self._last_activities_burst_complete:
                 return
-            self._ack_ready_refresh_pending = False
         new_id, old_id = self.state.update_activity_state()
         pending_redundant_off = self._pending_redundant_off_check
         self._pending_redundant_off_check = False

--- a/custom_components/sofabaton_x1s/lib/x1_proxy.py
+++ b/custom_components/sofabaton_x1s/lib/x1_proxy.py
@@ -465,6 +465,8 @@ class X1Proxy(FrameDecodeMixin, IrBlobMixin, CatalogMixin, ExchangeMixin, AckWai
         self._activity_request_serial = 0
         self._activity_request_inflight: int | None = None
         self._activities_catalog_ready = False
+        self._last_activities_burst_complete = False
+        self._activities_snapshot_generation = 0
         self._activity_retry_count = 0
         self._activity_retry_due_at: float | None = None
         self._activity_retry_send_pending = False
@@ -669,8 +671,10 @@ class X1Proxy(FrameDecodeMixin, IrBlobMixin, CatalogMixin, ExchangeMixin, AckWai
 
     def handle_active_state(self, trigger: str) -> None:
         if trigger == "activities":
-            # Whatever triggered this burst, state now mirrors hub rows:
-            # an ACK_READY refresh, if one was in flight, has landed.
+            # A scheduler timeout also ends a burst. Only a committed
+            # snapshot can confirm a state change or a redundant OFF press.
+            if not self._last_activities_burst_complete:
+                return
             self._ack_ready_refresh_pending = False
         new_id, old_id = self.state.update_activity_state()
         pending_redundant_off = self._pending_redundant_off_check

--- a/docs/protocol/reference-impl.md
+++ b/docs/protocol/reference-impl.md
@@ -96,13 +96,30 @@ snapshot; both active-state evaluation and the HA catalog listener require
 that proof. The HA listener captures it before scheduling work on its event
 loop, so a later burst cannot turn a discarded refresh into a successful one.
 
-The HA activity catalog refresh requires the proxy's committed generation to
-advance after the request starts, so delivery of an old queued HA callback
-cannot satisfy it. It raises `TimeoutError` when no complete snapshot arrives
+The proxy publishes each complete snapshot's generation and raw contents
+together. The HA listener acknowledges that same pair on the event loop;
+an explicit refresh requires the acknowledged generation to exceed the
+proxy generation observed before its request. An old queued HA callback and
+a newer proxy commit whose callback is still pending cannot satisfy each
+other. Validation and pruning use the acknowledged snapshot, including its
+raw bodies, rather than rereading mutable proxy or HA caches. Callbacks from
+a replaced proxy cannot acknowledge a refresh on its replacement.
+
+The refresh raises `TimeoutError` when no matching complete snapshot arrives
 before its deadline. The websocket API returns a `timeout`
 error and does not persist the cache. Removed activity details are pruned only
 after a successful refresh. A complete snapshot with no active row still
 reports Powered Off normally; retaining the cache does not debounce Off.
+
+A pending redundant-OFF press owns its queued confirmation request and the
+one permitted X2 retry. The send hook binds the press to that request when it
+leaves the queue, so earlier reads cannot confirm or cancel it. The intent
+expires on disconnect, when its own read fails without a remaining retry,
+when an unrelated read replaces its scheduled retry, or after 15 seconds.
+The retry can confirm the press within that deadline. A rejected confirmation
+request clears its intent as well. A later recovery or a delayed queued read
+cannot execute old button
+intent; a fresh Off press still fires once after a complete Off response.
 
 ---
 

--- a/docs/protocol/reference-impl.md
+++ b/docs/protocol/reference-impl.md
@@ -82,6 +82,30 @@ Guards:
 
 ---
 
+## ◇ Activity catalog refreshes
+
+`REQ_ACTIVITIES` collects rows in a pending snapshot. The committed catalog,
+active-activity hint, and cache readiness remain available during a refresh.
+Only a complete row set, or an explicit empty-catalog `STATUS_ACK 0x07`,
+replaces them. A silent or partial burst is discarded without publishing
+activity changes or confirming a pending redundant-OFF event.
+
+The burst scheduler also invokes end listeners on timeout, so its notification
+alone is not proof of success. `X1Proxy` records whether that burst committed a
+snapshot; both active-state evaluation and the HA catalog listener require
+that proof. The HA listener captures it before scheduling work on its event
+loop, so a later burst cannot turn a discarded refresh into a successful one.
+
+The HA activity catalog refresh requires the proxy's committed generation to
+advance after the request starts, so delivery of an old queued HA callback
+cannot satisfy it. It raises `TimeoutError` when no complete snapshot arrives
+before its deadline. The websocket API returns a `timeout`
+error and does not persist the cache. Removed activity details are pruned only
+after a successful refresh. A complete snapshot with no active row still
+reports Powered Off normally; retaining the cache does not debounce Off.
+
+---
+
 ## ◇ Unified create / restore orchestrator
 
 The user-driven "create WiFi device" path and the backup-driven

--- a/tests/test_activity_catalog_refresh.py
+++ b/tests/test_activity_catalog_refresh.py
@@ -1,0 +1,255 @@
+"""Activity refreshes must never turn missing replies into power events.
+
+Exercise the real request, snapshot and burst listeners through the HA hub.
+Only the transport and HA side effects are replaced; no hub is contacted.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.sofabaton_x1s import hub as hub_module
+from custom_components.sofabaton_x1s.hub import SofabatonHub
+
+
+class _Hass:
+    def __init__(self, loop):
+        self.loop = loop
+        self.data = {}
+        self.config_entries = SimpleNamespace(async_get_entry=lambda _id: None)
+
+    async def async_add_executor_job(self, func, *args):
+        return func(*args)
+
+    def async_create_task(self, coro):
+        return self.loop.create_task(coro)
+
+
+def _reply(proxy, rows):
+    assert proxy._burst.kind == "activities"
+    if not rows:
+        assert proxy.note_catalog_status_ack(0x07)
+        return
+    for index, (activity_id, name, active) in enumerate(rows, 1):
+        assert proxy.ingest_activity_row(
+            row_idx=index,
+            expected_rows=len(rows),
+            act_id=activity_id,
+            activity={"id": activity_id, "name": name, "active": active, "needs_confirm": False},
+        )
+    assert proxy.try_finish_activities_burst()
+
+
+def _expire(proxy, partial=False):
+    if partial:
+        assert proxy.ingest_activity_row(
+            row_idx=1,
+            expected_rows=2,
+            act_id=101,
+            activity={"id": 101, "name": "TV", "active": False, "needs_confirm": False},
+        )
+    proxy._burst.tick(
+        proxy._burst.last_ts + proxy._burst.idle_s + 1,
+        can_issue=proxy.can_issue_commands,
+        sender=proxy._send_cmd_frame,
+    )
+
+
+async def _drain():
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+
+@pytest.fixture
+def catalog(monkeypatch):
+    loop = asyncio.new_event_loop()
+    hass = _Hass(loop)
+    hub = SofabatonHub(
+        hass, "entry-id", "hub-name", "127.0.0.1", 1234, {}, 9999, 10000, False, False
+    )
+    proxy = hub._proxy
+    monkeypatch.setattr(proxy, "can_issue_commands", lambda: True)
+    monkeypatch.setattr(proxy.transport, "send_local", lambda _frame: None)
+    monkeypatch.setattr(hub, "_async_prime_buttons_for", AsyncMock())
+    monkeypatch.setattr(hub, "_async_prune_activity_event_actions", AsyncMock())
+    hub_actions = AsyncMock()
+    activity_actions = AsyncMock()
+    monkeypatch.setattr(hub, "_async_run_hub_event_action", hub_actions)
+    monkeypatch.setattr(hub, "_async_run_activity_event_action", activity_actions)
+    published = []
+    monkeypatch.setattr(
+        hub_module,
+        "async_dispatcher_send",
+        lambda _hass, signal, *args: published.append((signal, hub.current_activity)),
+    )
+    changes = []
+    proxy.on_activity_change(lambda new, old, name: changes.append((new, old)))
+    assert proxy.request_activities()
+    _reply(proxy, [(101, "TV", True), (102, "Music", False)])
+    loop.run_until_complete(_drain())
+    assert hub.current_activity == 101
+    assert hub.activities_ready
+    assert hub._hub_event_hooks_armed
+    changes.clear()
+    published.clear()
+    hub_actions.reset_mock()
+    activity_actions.reset_mock()
+    # Include a removed catalog entry and an auxiliary-only stale cache entry.
+    proxy.state.activity_macros = {101: [], 102: [], 103: []}
+    try:
+        yield SimpleNamespace(
+            hub=hub, proxy=proxy, loop=loop, changes=changes, published=published,
+            hub_actions=hub_actions, activity_actions=activity_actions,
+        )
+    finally:
+        for task in asyncio.all_tasks(loop):
+            task.cancel()
+        loop.run_until_complete(_drain())
+        loop.close()
+
+
+@pytest.mark.parametrize("partial", [False, True], ids=["silence", "partial"])
+def test_failed_refresh_preserves_activity_and_details_until_recovery(catalog, partial):
+    hub, proxy = catalog.hub, catalog.proxy
+    generation = hub._activities_generation
+    cache_generation = hub.cache_generation
+    original = dict(proxy.state.activities)
+
+    async def scenario():
+        task = asyncio.create_task(hub.async_request_catalog("activities", timeout_seconds=0.2))
+        await asyncio.sleep(0)
+        # The committed view must remain usable while the request is in flight.
+        assert proxy.get_activities(force_refresh=False) == (original, True)
+        assert proxy.state.current_activity_hint == 101
+        _expire(proxy, partial=partial)
+        await _drain()
+        assert hub.current_activity == proxy.state.current_activity == 101
+        assert hub.activities_ready
+        assert hub._activities_generation == generation
+        assert hub.cache_generation == cache_generation
+        assert catalog.changes == []
+        catalog.hub_actions.assert_not_awaited()
+        catalog.activity_actions.assert_not_awaited()
+        assert catalog.published == []
+        with pytest.raises(TimeoutError, match="activit"):
+            await task
+        assert set(proxy.state.activity_macros) == {101, 102, 103}
+
+        # A later valid reply commits and prunes removals without an Off/On bounce.
+        task = asyncio.create_task(hub.async_request_catalog("activities", timeout_seconds=0.5))
+        await asyncio.sleep(0)
+        _reply(proxy, [(101, "TV", True)])
+        await task
+        await _drain()
+        assert hub._activities_generation == generation + 1
+        assert set(hub.activities) == {101}
+        assert set(proxy.state.activity_macros) == {101}
+        assert catalog.changes == []
+        catalog.hub_actions.assert_not_awaited()
+        catalog.activity_actions.assert_not_awaited()
+        assert all(activity == 101 for _signal, activity in catalog.published)
+
+    catalog.loop.run_until_complete(scenario())
+
+
+@pytest.mark.parametrize("empty", [False, True], ids=["inactive-rows", "empty-ack"])
+def test_complete_off_reply_still_fires_stop_and_power_off(catalog, empty):
+    hub, proxy = catalog.hub, catalog.proxy
+    generation = hub._activities_generation
+
+    async def scenario():
+        task = asyncio.create_task(hub.async_request_catalog("activities", timeout_seconds=0.5))
+        await asyncio.sleep(0)
+        _reply(proxy, [] if empty else [(101, "TV", False), (102, "Music", False)])
+        await task
+        await _drain()
+
+    catalog.loop.run_until_complete(scenario())
+    assert hub.current_activity is proxy.state.current_activity is None
+    assert hub._activities_generation == generation + 1
+    assert hub.activities_ready
+    assert catalog.changes == [(None, 101)]
+    catalog.activity_actions.assert_awaited_once_with(101, "stop")
+    assert [call.args for call in catalog.hub_actions.await_args_list] == [
+        ("activity_stop",), ("power_off",)
+    ]
+    assert set(proxy.state.activity_macros) == (set() if empty else {101, 102})
+
+
+def test_incomplete_burst_does_not_confirm_pending_redundant_off(catalog):
+    hub, proxy = catalog.hub, catalog.proxy
+    assert proxy.request_activities()
+    _reply(proxy, [(101, "TV", False)])
+    catalog.loop.run_until_complete(_drain())
+    catalog.hub_actions.reset_mock()
+    catalog.activity_actions.reset_mock()
+    catalog.changes.clear()
+    generation = hub._activities_generation
+    proxy.flag_pending_redundant_off_check()
+    proxy._ack_ready_refresh_pending = True
+
+    assert proxy.request_activities()
+    _expire(proxy)
+    catalog.loop.run_until_complete(_drain())
+    assert proxy._pending_redundant_off_check
+    assert proxy._ack_ready_refresh_pending
+    assert hub._activities_generation == generation
+    catalog.hub_actions.assert_not_awaited()
+
+    assert proxy.request_activities()
+    _reply(proxy, [(101, "TV", False)])
+    catalog.loop.run_until_complete(_drain())
+    catalog.hub_actions.assert_awaited_once_with("redundant_off")
+    assert not proxy._pending_redundant_off_check
+    assert not proxy._ack_ready_refresh_pending
+    assert catalog.changes == []
+
+
+def test_queued_old_completion_cannot_satisfy_a_new_refresh(catalog):
+    hub, proxy = catalog.hub, catalog.proxy
+    generation = hub._activities_generation
+
+    async def scenario():
+        assert proxy.request_activities()
+        _reply(proxy, [(101, "TV", True), (102, "Music", False)])
+        # The proxy has committed, but its HA callback has not run yet.
+        assert hub._activities_generation == generation
+        catalog.loop.call_soon(_expire, proxy)
+        with pytest.raises(TimeoutError):
+            await hub.async_request_catalog("activities", timeout_seconds=0.2)
+        assert hub._activities_generation == generation + 1
+        assert set(proxy.state.activity_macros) == {101, 102, 103}
+        assert catalog.changes == []
+
+    catalog.loop.run_until_complete(scenario())
+
+
+def test_burst_outcome_is_captured_before_ha_callbacks_run(catalog):
+    hub, proxy = catalog.hub, catalog.proxy
+    generation = hub._activities_generation
+
+    assert proxy.request_activities()
+    _expire(proxy)
+    assert proxy.request_activities()
+    _reply(proxy, [(101, "TV", True)])
+    # Both bursts finish before the event loop gets a turn. The discarded
+    # burst must not inherit the later successful burst's ready flag.
+    catalog.loop.run_until_complete(_drain())
+    assert hub._activities_generation == generation + 1
+    assert catalog.changes == []
+
+
+def test_external_off_still_applies_after_a_failed_tcp_refresh(catalog):
+    proxy = catalog.proxy
+    assert proxy.request_activities()
+    _expire(proxy)
+    catalog.loop.run_until_complete(_drain())
+    assert proxy.apply_external_activity_state(None)
+    catalog.loop.run_until_complete(_drain())
+    assert catalog.hub.current_activity is None
+    assert catalog.changes == [(None, 101)]
+    assert [call.args for call in catalog.hub_actions.await_args_list] == [
+        ("activity_stop",), ("power_off",)
+    ]

--- a/tests/test_activity_catalog_refresh.py
+++ b/tests/test_activity_catalog_refresh.py
@@ -5,15 +5,18 @@ Only the transport and HA side effects are replaced; no hub is contacted.
 """
 
 import asyncio
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
 from custom_components.sofabaton_x1s import hub as hub_module
-from custom_components.sofabaton_x1s.const import HUB_VERSION_X2
+from custom_components.sofabaton_x1s.const import HUB_VERSION_X1, HUB_VERSION_X1S, HUB_VERSION_X2
 from custom_components.sofabaton_x1s.hub import SofabatonHub
 from custom_components.sofabaton_x1s.lib.frame_handlers import FrameContext
+from custom_components.sofabaton_x1s.lib import x1_proxy as proxy_module
+from custom_components.sofabaton_x1s.lib import proxy_catalog as catalog_module
 from custom_components.sofabaton_x1s.lib.opcode_handlers import AckReadyHandler
 from custom_components.sofabaton_x1s.lib.protocol_const import OP_ACK_READY
 
@@ -182,8 +185,9 @@ def test_complete_off_reply_still_fires_stop_and_power_off(catalog, empty):
     assert set(proxy.state.activity_macros) == (set() if empty else {101, 102})
 
 
-def test_incomplete_burst_does_not_confirm_pending_redundant_off(catalog):
+def test_x2_retry_can_confirm_pending_redundant_off(catalog):
     hub, proxy = catalog.hub, catalog.proxy
+    proxy.hub_version = HUB_VERSION_X2
     assert proxy.request_activities()
     _reply(proxy, [(101, "TV", False)])
     catalog.loop.run_until_complete(_drain())
@@ -191,10 +195,10 @@ def test_incomplete_burst_does_not_confirm_pending_redundant_off(catalog):
     catalog.activity_actions.reset_mock()
     catalog.changes.clear()
     generation = hub._activities_generation
-    proxy.flag_pending_redundant_off_check()
-    proxy._ack_ready_refresh_pending = True
-
-    assert proxy.request_activities()
+    AckReadyHandler().handle(FrameContext(
+        proxy=proxy, opcode=OP_ACK_READY, direction="H→A",
+        payload=b"\x00", raw=b"", name="ACK_READY",
+    ))
     _expire(proxy)
     catalog.loop.run_until_complete(_drain())
     assert proxy._pending_redundant_off_check
@@ -202,7 +206,8 @@ def test_incomplete_burst_does_not_confirm_pending_redundant_off(catalog):
     assert hub._activities_generation == generation
     catalog.hub_actions.assert_not_awaited()
 
-    assert proxy.request_activities()
+    assert proxy._activity_retry_due_at is not None
+    proxy._handle_idle(proxy._activity_retry_due_at)
     _reply(proxy, [(101, "TV", False)])
     catalog.loop.run_until_complete(_drain())
     catalog.hub_actions.assert_awaited_once_with("redundant_off")
@@ -300,3 +305,324 @@ def test_external_off_after_failed_ack_refresh_is_not_redundant(catalog):
     _reply(proxy, [(101, "TV", False), (102, "Music", False)])
     catalog.loop.run_until_complete(_drain())
     catalog.hub_actions.assert_awaited_once_with("redundant_off")
+
+
+@pytest.mark.parametrize("operation", ["catalog", "command_sync"])
+def test_new_proxy_commit_waits_for_its_own_ha_delivery(catalog, monkeypatch, operation):
+    """An old HA callback and a new proxy commit cannot acknowledge each other."""
+    hub, proxy, loop = catalog.hub, catalog.proxy, catalog.loop
+    hub.roku_server_enabled = True
+    queued = []
+    call_soon_threadsafe = loop.call_soon_threadsafe
+    monkeypatch.setattr(loop, "call_soon_threadsafe", lambda cb, *args: queued.append((cb, args)))
+    assert proxy.request_activities()
+    _reply(proxy, [(101, "TV", True), (102, "Music", False)])
+    monkeypatch.setattr(loop, "call_soon_threadsafe", call_soon_threadsafe)
+    assert len(queued) == 1
+    assert hub._activities_generation < proxy._activities_snapshot_generation
+
+    async def threaded_executor(func, *args):
+        return await asyncio.to_thread(func, *args)
+
+    monkeypatch.setattr(hub.hass, "async_add_executor_job", threaded_executor)
+    requested, committed = asyncio.Event(), asyncio.Event()
+    release_delivery = threading.Event()
+    request_activities = proxy.request_activities
+
+    def request_new_snapshot():
+        sent = request_activities()
+        # The refresh has now recorded its baselines. Deliver the older
+        # callback while the newer response is still outstanding.
+        for cb, args in queued:
+            call_soon_threadsafe(cb, *args)
+        call_soon_threadsafe(requested.set)
+        return sent
+
+    monkeypatch.setattr(proxy, "request_activities", request_new_snapshot)
+    log_info = proxy._log.info
+
+    def pause_after_commit(message, *args, **kwargs):
+        log_info(message, *args, **kwargs)
+        if message.startswith("[ACT] committed complete activities snapshot"):
+            call_soon_threadsafe(committed.set)
+            assert release_delivery.wait(10), "test did not release the frame thread"
+
+    monkeypatch.setattr(proxy._log, "info", pause_after_commit)
+    device_refresh = AsyncMock(side_effect=AssertionError("sync passed stale activity validation"))
+    monkeypatch.setattr(hub, "_async_refresh_devices_snapshot", device_refresh)
+    delete_device = AsyncMock()
+    monkeypatch.setattr(hub, "async_delete_device", delete_device)
+    payload = {
+        "commands": [{"name": "Command 1", "add_as_favorite": True, "activities": ["101"]}],
+        "commands_hash": "abc",
+        "activity_labels": {"101": "TV"},
+    }
+
+    async def scenario():
+        if operation == "catalog":
+            task = asyncio.create_task(hub.async_request_catalog("activities", timeout_seconds=2))
+        else:
+            task = asyncio.create_task(hub.async_sync_command_config(command_payload=payload, request_port=8060))
+        response = None
+        try:
+            await asyncio.wait_for(requested.wait(), 5)
+            response = asyncio.create_task(asyncio.to_thread(_reply, proxy, [(101, "Movie Night", True)]))
+            await asyncio.wait_for(committed.wait(), 5)
+            assert hub.activities[101]["name"] == "TV"
+            assert proxy.state.activities[101]["name"] == "Movie Night"
+            # Let the real refresh waiter run while B's frame thread is held
+            # between its commit and its HA callback, not inside an inline stub.
+            await asyncio.sleep(0.15)
+            assert not task.done(), "a different snapshot's HA callback satisfied the refresh"
+            assert set(proxy.state.activity_macros) == {101, 102, 103}
+            device_refresh.assert_not_awaited()
+            delete_device.assert_not_awaited()
+
+            release_delivery.set()
+            await response
+            if operation == "command_sync":
+                from homeassistant.exceptions import HomeAssistantError
+
+                with pytest.raises(HomeAssistantError, match="Failed Activity validation"):
+                    await task
+                device_refresh.assert_not_awaited()
+                delete_device.assert_not_awaited()
+            else:
+                await task
+            assert hub.activities[101]["name"] == "Movie Night"
+            assert set(proxy.state.activity_macros) == {101}
+        finally:
+            release_delivery.set()
+            if response is not None:
+                await asyncio.gather(response, return_exceptions=True)
+            if not task.done():
+                task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            await loop.shutdown_default_executor()
+
+    loop.run_until_complete(scenario())
+
+
+def test_snapshot_result_keeps_its_captured_contents(catalog):
+    hub, proxy, loop = catalog.hub, catalog.proxy, catalog.loop
+
+    async def scenario():
+        task = asyncio.create_task(hub._async_refresh_activities_snapshot(timeout_seconds=0.5))
+        await asyncio.sleep(0)
+        _reply(proxy, [(101, "Movie Night", True)])
+        # The commit is queued for HA delivery. A later cache mutation must
+        # not replace the contents paired with that commit's acknowledgment.
+        proxy.state.activities[101]["name"] = "Undelivered change"
+        snapshot = await task
+        assert snapshot[101]["name"] == hub.activities[101]["name"] == "Movie Night"
+        snapshot[101]["name"] = "Caller edit"
+        assert hub.activities[101]["name"] == "Movie Night"
+        assert proxy._committed_activity_snapshot[1][101]["name"] == "Movie Night"
+
+    loop.run_until_complete(scenario())
+
+
+def test_replaced_proxy_cannot_deliver_a_queued_snapshot(catalog, monkeypatch):
+    hub, proxy, loop = catalog.hub, catalog.proxy, catalog.loop
+    assert proxy.request_activities()
+    _reply(proxy, [(101, "Old proxy", True)])
+    replacement = hub._create_proxy()
+    hub._proxy = replacement
+    monkeypatch.setattr(replacement, "can_issue_commands", lambda: True)
+    monkeypatch.setattr(replacement.transport, "send_local", lambda _frame: None)
+    loop.run_until_complete(_drain())
+    assert hub.activities[101]["name"] == "TV"
+    # The previous proxy's generations exceed the fresh proxy's zero, but
+    # they cannot acknowledge its request or trigger detail pruning.
+    with pytest.raises(TimeoutError):
+        loop.run_until_complete(hub.async_request_catalog("activities", timeout_seconds=0.05))
+    assert set(proxy.state.activity_macros) == {101, 102, 103}
+
+
+@pytest.mark.parametrize("version", [HUB_VERSION_X1, HUB_VERSION_X1S, HUB_VERSION_X2])
+@pytest.mark.parametrize("exhaust_attempts", [False, True], ids=["inflight", "exhausted"])
+def test_failed_off_confirmation_cannot_fire_after_reconnect(catalog, monkeypatch, version, exhaust_attempts):
+    hub, proxy, loop = catalog.hub, catalog.proxy, catalog.loop
+    proxy.hub_version = version
+    monkeypatch.setattr(hub, "_async_initial_sync", AsyncMock())
+    assert proxy.request_activities()
+    _reply(proxy, [(101, "TV", False)])
+    loop.run_until_complete(_drain())
+    catalog.hub_actions.reset_mock()
+    handler = AckReadyHandler()
+    frame = FrameContext(
+        proxy=proxy, opcode=OP_ACK_READY, direction="H→A",
+        payload=b"\x00", raw=b"", name="ACK_READY",
+    )
+
+    handler.handle(frame)
+    assert proxy._pending_redundant_off_check
+    if exhaust_attempts:
+        _expire(proxy)
+        if version == HUB_VERSION_X2:
+            assert proxy._activity_retry_due_at is not None
+            proxy._handle_idle(proxy._activity_retry_due_at)
+            _expire(proxy)
+    loop.run_until_complete(_drain())
+    catalog.hub_actions.assert_not_awaited()
+
+    proxy._notify_hub_state(False)
+    proxy._notify_hub_state(True)
+    loop.run_until_complete(_drain())
+    if not proxy._burst.active:
+        assert proxy.request_activities()
+    _reply(proxy, [(101, "TV", False)])
+    loop.run_until_complete(_drain())
+    catalog.hub_actions.assert_not_awaited()
+
+    handler.handle(frame)
+    _reply(proxy, [(101, "TV", False)])
+    loop.run_until_complete(_drain())
+    catalog.hub_actions.assert_awaited_once_with("redundant_off")
+
+
+@pytest.mark.parametrize("version", [HUB_VERSION_X1, HUB_VERSION_X1S, HUB_VERSION_X2])
+def test_failed_off_confirmation_expires_without_disconnect(catalog, version):
+    proxy, loop = catalog.proxy, catalog.loop
+    proxy.hub_version = version
+    assert proxy.request_activities()
+    _reply(proxy, [(101, "TV", False)])
+    loop.run_until_complete(_drain())
+    catalog.hub_actions.reset_mock()
+    frame = FrameContext(
+        proxy=proxy, opcode=OP_ACK_READY, direction="H→A",
+        payload=b"\x00", raw=b"", name="ACK_READY",
+    )
+    AckReadyHandler().handle(frame)
+    _expire(proxy)
+    if version == HUB_VERSION_X2:
+        proxy._handle_idle(proxy._activity_retry_due_at)
+        _expire(proxy)
+    assert not proxy._pending_redundant_off_check
+    assert proxy.request_activities()
+    _reply(proxy, [(101, "TV", False)])
+    loop.run_until_complete(_drain())
+    catalog.hub_actions.assert_not_awaited()
+
+
+@pytest.mark.parametrize("idle_tick", [False, True])
+def test_queued_off_confirmation_has_a_deadline(catalog, monkeypatch, idle_tick):
+    proxy, loop = catalog.proxy, catalog.loop
+    assert proxy.request_activities()
+    _reply(proxy, [(101, "TV", False)])
+    loop.run_until_complete(_drain())
+    catalog.hub_actions.reset_mock()
+    clock = SimpleNamespace(now=100.0)
+    fake_time = SimpleNamespace(monotonic=lambda: clock.now)
+    monkeypatch.setattr(proxy_module, "time", fake_time)
+    monkeypatch.setattr(catalog_module, "time", fake_time)
+    # A command exchange can hold the wire much longer than a catalog burst.
+    # Its eventual release must not revive a minute-old button press.
+    proxy._burst.start("exchange:test")
+    frame = FrameContext(
+        proxy=proxy, opcode=OP_ACK_READY, direction="H→A",
+        payload=b"\x00", raw=b"", name="ACK_READY",
+    )
+    handler = AckReadyHandler()
+    handler.handle(frame)
+    assert proxy._pending_redundant_off_check
+    clock.now += 60
+    if idle_tick:
+        proxy._handle_idle(clock.now)
+    assert proxy._burst.finish(
+        "exchange:test", can_issue=proxy.can_issue_commands, sender=proxy._send_cmd_frame
+    )
+    _reply(proxy, [(101, "TV", False)])
+    loop.run_until_complete(_drain())
+    catalog.hub_actions.assert_not_awaited()
+    assert not proxy._pending_redundant_off_check
+
+    handler.handle(frame)
+    _reply(proxy, [(101, "TV", False)])
+    loop.run_until_complete(_drain())
+    catalog.hub_actions.assert_awaited_once_with("redundant_off")
+
+
+@pytest.mark.parametrize("version", [HUB_VERSION_X1, HUB_VERSION_X1S, HUB_VERSION_X2])
+@pytest.mark.parametrize("older_result", ["silence", "partial", "complete"])
+@pytest.mark.parametrize("extra_queued_read", [False, True])
+def test_fresh_off_confirmation_waits_for_its_own_queued_read(
+    catalog, version, older_result, extra_queued_read
+):
+    proxy, loop = catalog.proxy, catalog.loop
+    proxy.hub_version = version
+    assert proxy.request_activities()
+    _reply(proxy, [(101, "TV", False)])
+    loop.run_until_complete(_drain())
+    catalog.hub_actions.reset_mock()
+
+    # The ordinary read A, and optionally C, precede this actual Off press.
+    assert proxy.request_activities()
+    if extra_queued_read:
+        assert proxy.request_activities()
+    AckReadyHandler().handle(FrameContext(
+        proxy=proxy, opcode=OP_ACK_READY, direction="H→A",
+        payload=b"\x00", raw=b"", name="ACK_READY",
+    ))
+
+    for _ in range(2 if extra_queued_read else 1):
+        if older_result == "complete":
+            _reply(proxy, [(101, "TV", False)])
+        else:
+            _expire(proxy, partial=older_result == "partial")
+        loop.run_until_complete(_drain())
+        catalog.hub_actions.assert_not_awaited()
+    assert proxy._pending_redundant_off_check
+
+    # Only the ACK-triggered confirmation B may consume the fresh intent.
+    _reply(proxy, [(101, "TV", False)])
+    loop.run_until_complete(_drain())
+    catalog.hub_actions.assert_awaited_once_with("redundant_off")
+    assert not proxy._pending_redundant_off_check
+
+
+def test_newer_off_press_is_not_bound_to_an_older_queued_confirmation(catalog):
+    proxy, loop = catalog.proxy, catalog.loop
+    assert proxy.request_activities()
+    _reply(proxy, [(101, "TV", False)])
+    loop.run_until_complete(_drain())
+    catalog.hub_actions.reset_mock()
+    assert proxy.request_activities()
+    handler = AckReadyHandler()
+    frame = FrameContext(
+        proxy=proxy, opcode=OP_ACK_READY, direction="H→A",
+        payload=b"\x00", raw=b"", name="ACK_READY",
+    )
+    handler.handle(frame)
+    handler.handle(frame)
+    # Ordinary read A and the superseded press's B must leave the latest
+    # pending press alone. Its own confirmation C consumes it once.
+    for _ in range(2):
+        _reply(proxy, [(101, "TV", False)])
+        loop.run_until_complete(_drain())
+        catalog.hub_actions.assert_not_awaited()
+    _reply(proxy, [(101, "TV", False)])
+    loop.run_until_complete(_drain())
+    catalog.hub_actions.assert_awaited_once_with("redundant_off")
+
+
+def test_unrelated_read_cannot_replace_an_off_confirmations_x2_retry(catalog):
+    proxy, loop = catalog.proxy, catalog.loop
+    proxy.hub_version = HUB_VERSION_X2
+    assert proxy.request_activities()
+    _reply(proxy, [(101, "TV", False)])
+    loop.run_until_complete(_drain())
+    catalog.hub_actions.reset_mock()
+    AckReadyHandler().handle(FrameContext(
+        proxy=proxy, opcode=OP_ACK_READY, direction="H→A",
+        payload=b"\x00", raw=b"", name="ACK_READY",
+    ))
+    _expire(proxy)
+    assert proxy._activity_retry_due_at is not None
+    # This normal poll cancels the scheduled retry in _begin_activity_request.
+    assert proxy.request_activities()
+    assert proxy._activity_retry_due_at is None
+    _reply(proxy, [(101, "TV", False)])
+    loop.run_until_complete(_drain())
+    catalog.hub_actions.assert_not_awaited()
+    assert not proxy._pending_redundant_off_check

--- a/tests/test_activity_catalog_refresh.py
+++ b/tests/test_activity_catalog_refresh.py
@@ -11,7 +11,11 @@ from unittest.mock import AsyncMock
 import pytest
 
 from custom_components.sofabaton_x1s import hub as hub_module
+from custom_components.sofabaton_x1s.const import HUB_VERSION_X2
 from custom_components.sofabaton_x1s.hub import SofabatonHub
+from custom_components.sofabaton_x1s.lib.frame_handlers import FrameContext
+from custom_components.sofabaton_x1s.lib.opcode_handlers import AckReadyHandler
+from custom_components.sofabaton_x1s.lib.protocol_const import OP_ACK_READY
 
 
 class _Hass:
@@ -194,7 +198,7 @@ def test_incomplete_burst_does_not_confirm_pending_redundant_off(catalog):
     _expire(proxy)
     catalog.loop.run_until_complete(_drain())
     assert proxy._pending_redundant_off_check
-    assert proxy._ack_ready_refresh_pending
+    assert not proxy._ack_ready_refresh_pending
     assert hub._activities_generation == generation
     catalog.hub_actions.assert_not_awaited()
 
@@ -253,3 +257,46 @@ def test_external_off_still_applies_after_a_failed_tcp_refresh(catalog):
     assert [call.args for call in catalog.hub_actions.await_args_list] == [
         ("activity_stop",), ("power_off",)
     ]
+
+
+def test_external_off_after_failed_ack_refresh_is_not_redundant(catalog):
+    proxy = catalog.proxy
+    proxy.hub_version = HUB_VERSION_X2
+    proxy.state.buttons[101] = set()
+    handler = AckReadyHandler()
+    frame = FrameContext(
+        proxy=proxy, opcode=OP_ACK_READY, direction="H→A",
+        payload=b"\x00", raw=b"", name="ACK_READY",
+    )
+
+    # An earlier transition's ACK refresh and its one X2 retry both time out.
+    handler.handle(frame)
+    assert proxy._ack_ready_refresh_pending
+    _expire(proxy)
+    assert proxy._activity_retry_due_at is not None
+    proxy._handle_idle(proxy._activity_retry_due_at)
+    _expire(proxy)
+    assert proxy._activity_retry_due_at is None
+    catalog.loop.run_until_complete(_drain())
+    assert catalog.hub.current_activity == 101
+
+    # The next real Off arrives over MQTT before its ACK. It must arm the
+    # settling gate so that ACK is recognized as part of this transition.
+    assert proxy.apply_external_activity_state(None)
+    assert not proxy._external_settle_event.is_set()
+    handler.handle(frame)
+    assert proxy._external_settle_event.is_set()
+    _reply(proxy, [(101, "TV", False), (102, "Music", False)])
+    catalog.loop.run_until_complete(_drain())
+    assert catalog.changes == [(None, 101)]
+    assert [call.args for call in catalog.hub_actions.await_args_list] == [
+        ("activity_stop",), ("power_off",)
+    ]
+    assert not proxy._ack_ready_refresh_pending
+
+    # A later Off press while already Off still fires exactly once.
+    catalog.hub_actions.reset_mock()
+    handler.handle(frame)
+    _reply(proxy, [(101, "TV", False), (102, "Music", False)])
+    catalog.loop.run_until_complete(_drain())
+    catalog.hub_actions.assert_awaited_once_with("redundant_off")

--- a/tests/test_cache_refresh_ws.py
+++ b/tests/test_cache_refresh_ws.py
@@ -3,6 +3,9 @@
 import asyncio
 import importlib
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
 
 from homeassistant.exceptions import HomeAssistantError
 
@@ -61,6 +64,46 @@ def _patch(monkeypatch, *, hub=_Hub(), locked=False, store=None):
             raise HomeAssistantError("The Sofabaton app is connected")
 
     monkeypatch.setattr(integration, "_raise_if_hub_operation_locked", fake_lock)
+
+
+def test_ws_catalog_timeout_does_not_report_success_or_persist_cache(monkeypatch):
+    conn = _Conn()
+    hub = _Hub()
+    hub.async_request_catalog = AsyncMock(side_effect=TimeoutError("Incomplete activities catalog"))
+    hub.async_export_cache_state = AsyncMock()
+    store = _Store()
+    store.async_set_hub_cache = AsyncMock()
+    _patch(monkeypatch, hub=hub, store=store)
+
+    _run(integration._ws_refresh_catalog(SimpleNamespace(), conn, {
+        "id": 1, "entry_id": hub.entry_id, "kind": "activities",
+    }))
+
+    assert conn.result is None
+    assert conn.error == (1, "timeout", "Incomplete activities catalog")
+    hub.async_export_cache_state.assert_not_awaited()
+    store.async_set_hub_cache.assert_not_awaited()
+
+
+@pytest.mark.parametrize("kind", ["activities", "devices"])
+def test_ws_catalog_success_persists_refreshed_cache(monkeypatch, kind):
+    conn = _Conn()
+    hub = _Hub()
+    hub.async_request_catalog = AsyncMock()
+    payload = {kind: {"101": {"name": "TV"}}}
+    hub.async_export_cache_state = AsyncMock(return_value=payload)
+    store = _Store()
+    store.async_set_hub_cache = AsyncMock()
+    _patch(monkeypatch, hub=hub, store=store)
+
+    _run(integration._ws_refresh_catalog(SimpleNamespace(), conn, {
+        "id": 1, "entry_id": hub.entry_id, "kind": kind,
+    }))
+
+    assert conn.error is None
+    assert conn.result == (1, {"ok": True})
+    hub.async_request_catalog.assert_awaited_once_with(kind)
+    store.async_set_hub_cache.assert_awaited_once_with(hub.entry_id, payload)
 
 
 def test_ws_refresh_all_cache_starts_operation(monkeypatch):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -207,7 +207,7 @@ def test_full_command_burst_drains_immediately_when_final_page_arrives(monkeypat
     )
 
     proxy._pending_command_requests[dev_id] = {0xFF}
-    proxy._burst.queue.append((0x025C, b"\x2b\xff", True, "commands:43"))
+    proxy._burst.queue.append((0x025C, b"\x2b\xff", True, "commands:43", None))
 
     sent: list[tuple[int, bytes]] = []
 
@@ -1167,7 +1167,7 @@ def test_single_command_handler_drains_targeted_command_burst_immediately(monkey
     proxy._burst.kind = "commands:1:2"
     proxy._burst.last_ts = 0.0
     proxy._pending_command_requests[1] = {0x02, 0x03}
-    proxy._burst.queue.append((0x025C, b"\x01\x03", True, "commands:1:3"))
+    proxy._burst.queue.append((0x025C, b"\x01\x03", True, "commands:1:3", None))
 
     sent: list[tuple[int, bytes]] = []
 

--- a/tests/test_hub_commands.py
+++ b/tests/test_hub_commands.py
@@ -5233,7 +5233,7 @@ def test_sync_command_config_aborts_on_activity_label_mismatch(monkeypatch):
 
 def test_sync_command_config_aborts_when_activity_refresh_fails(monkeypatch):
     """If the fresh activity read never lands, abort instead of deploying
-    against a stale (now cleared) catalog."""
+    against the preserved but stale catalog."""
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
@@ -5255,7 +5255,7 @@ def test_sync_command_config_aborts_when_activity_refresh_fails(monkeypatch):
     monkeypatch.setattr(hub._proxy, "can_issue_commands", lambda: True)
 
     async def _request_catalog(kind, timeout_seconds=30.0):
-        return None  # no generation bump: the burst never arrived
+        raise TimeoutError("Timed out waiting for a complete activities catalog from the hub")
 
     monkeypatch.setattr(hub, "async_request_catalog", _request_catalog)
 
@@ -5275,12 +5275,16 @@ def test_sync_command_config_aborts_when_activity_refresh_fails(monkeypatch):
 
     from homeassistant.exceptions import HomeAssistantError
 
-    with pytest.raises(HomeAssistantError, match="Failed to refresh the Activity list"):
+    with pytest.raises(HomeAssistantError, match="Failed to refresh the Activity list") as err:
         loop.run_until_complete(
             hub.async_sync_command_config(command_payload=payload, request_port=8060)
         )
 
     assert delete_calls == []
+    assert isinstance(err.value.__cause__, TimeoutError)
+    progress = hub.get_command_sync_progress()
+    assert progress["status"] == "failed"
+    assert "Failed to refresh the Activity list" in progress["message"]
 
     loop.close()
 

--- a/tests/test_hub_commands.py
+++ b/tests/test_hub_commands.py
@@ -60,6 +60,20 @@ class FakeDeviceRegistry:
         self.updated.append((device_id, kwargs))
 
 
+def _publish_activity_snapshot(hub):
+    """Deliver the unit fixture's catalog as an identified proxy commit."""
+    activities, ready = hub._get_activities_cached()
+    assert ready
+    proxy = hub._proxy
+    proxy._activities_snapshot_generation += 1
+    proxy._committed_activity_snapshot = (
+        proxy._activities_snapshot_generation,
+        {act_id: dict(row) for act_id, row in activities.items()},
+    )
+    proxy._last_activities_burst_complete = True
+    hub._on_activities_burst("activities")
+
+
 def test_activity_fetch_clears_inflight_after_favorite_labels(monkeypatch):
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
@@ -1746,8 +1760,7 @@ def test_identical_activity_refresh_does_not_bump_cache_generation(monkeypatch):
         lambda: ({101: {"name": "Watch TV", "active": False, "needs_confirm": False}}, True),
     )
 
-    hub._proxy._last_activities_burst_complete = True
-    hub._on_activities_burst("activities")
+    _publish_activity_snapshot(hub)
     loop.run_until_complete(asyncio.sleep(0))
 
     assert hub.cache_generation == 0
@@ -1783,8 +1796,7 @@ def test_activity_active_flag_changes_without_bumping_cache_generation(monkeypat
         lambda: ({101: {"name": "Watch TV", "active": True, "needs_confirm": False}}, True),
     )
 
-    hub._proxy._last_activities_burst_complete = True
-    hub._on_activities_burst("activities")
+    _publish_activity_snapshot(hub)
     loop.run_until_complete(asyncio.sleep(0))
 
     assert hub.cache_generation == 0
@@ -1820,8 +1832,7 @@ def test_activity_catalog_name_change_bumps_cache_generation(monkeypatch):
         lambda: ({101: {"name": "New Name", "active": False, "needs_confirm": False}}, True),
     )
 
-    hub._proxy._last_activities_burst_complete = True
-    hub._on_activities_burst("activities")
+    _publish_activity_snapshot(hub)
     loop.run_until_complete(asyncio.sleep(0))
 
     assert hub.cache_generation == 1
@@ -2691,8 +2702,7 @@ def test_on_activities_burst_syncs_current_activity_from_active_flag(monkeypatch
     )
 
     hub.current_activity = None
-    hub._proxy._last_activities_burst_complete = True
-    hub._on_activities_burst("activities")
+    _publish_activity_snapshot(hub)
     loop.run_until_complete(asyncio.sleep(0))
 
     assert hub.current_activity == 101
@@ -2804,8 +2814,7 @@ def test_activities_burst_can_clear_current_when_no_activity_active(monkeypatch)
         lambda: ({101: {"name": "Watch a movie", "active": False}}, True),
     )
 
-    hub._proxy._last_activities_burst_complete = True
-    hub._on_activities_burst("activities")
+    _publish_activity_snapshot(hub)
     loop.run_until_complete(asyncio.sleep(0))
 
     assert hub.current_activity is None
@@ -5154,6 +5163,9 @@ def test_async_request_catalog_prunes_auxiliary_only_removed_activity_ids(monkey
     async def _fake_sleep(_delay):
         hub._proxy._activities_snapshot_generation = 1
         hub._activities_generation = 3
+        hub._received_activity_snapshot = (
+            hub._proxy, 1, {101: {"name": "TV"}, 102: {"name": "Music"}},
+        )
 
     monkeypatch.setattr("custom_components.sofabaton_x1s.hub.asyncio.sleep", _fake_sleep)
     monkeypatch.setattr("custom_components.sofabaton_x1s.hub.async_dispatcher_send", lambda *_: None)
@@ -5193,7 +5205,10 @@ def test_sync_command_config_aborts_on_activity_label_mismatch(monkeypatch):
     async def _request_catalog(kind, timeout_seconds=30.0):
         catalog_calls.append(kind)
         hub._activities_generation += 1
-        hub.activities = {101: {"name": "Movie Night", "active": False}}
+        # Validation must use this request's returned snapshot even if the
+        # general-purpose HA cache is subsequently replaced by another view.
+        hub.activities = {101: {"name": "TV", "active": False}}
+        return {101: {"name": "Movie Night", "active": False}}
 
     monkeypatch.setattr(hub, "async_request_catalog", _request_catalog)
 
@@ -5318,6 +5333,7 @@ def test_sync_command_config_proceeds_when_activity_labels_match(monkeypatch):
         catalog_calls.append(kind)
         hub._activities_generation += 1
         hub.activities = {101: {"name": "TV", "active": False}}
+        return dict(hub.activities)
 
     monkeypatch.setattr(hub, "async_request_catalog", _request_catalog)
 
@@ -5584,8 +5600,7 @@ def test_hub_event_actions_fire_on_first_transition_after_powered_off_startup(mo
     hub, loop, executed, drain = _make_event_hook_hub(monkeypatch)
     try:
         monkeypatch.setattr(hub, "_get_activities_cached", lambda: ({}, True))
-        hub._proxy._last_activities_burst_complete = True
-        hub._on_activities_burst("activities")
+        _publish_activity_snapshot(hub)
         drain()
         assert executed == []
         assert hub.get_last_hub_event() is None
@@ -5758,8 +5773,7 @@ def test_activities_burst_prunes_stale_activity_event_actions(monkeypatch):
         lambda: ({102: {"name": "Music", "active": False, "needs_confirm": False}}, True),
     )
 
-    hub._proxy._last_activities_burst_complete = True
-    hub._on_activities_burst("activities")
+    _publish_activity_snapshot(hub)
     loop.run_until_complete(asyncio.sleep(0))
     loop.run_until_complete(asyncio.sleep(0))
 

--- a/tests/test_hub_commands.py
+++ b/tests/test_hub_commands.py
@@ -1746,6 +1746,7 @@ def test_identical_activity_refresh_does_not_bump_cache_generation(monkeypatch):
         lambda: ({101: {"name": "Watch TV", "active": False, "needs_confirm": False}}, True),
     )
 
+    hub._proxy._last_activities_burst_complete = True
     hub._on_activities_burst("activities")
     loop.run_until_complete(asyncio.sleep(0))
 
@@ -1782,6 +1783,7 @@ def test_activity_active_flag_changes_without_bumping_cache_generation(monkeypat
         lambda: ({101: {"name": "Watch TV", "active": True, "needs_confirm": False}}, True),
     )
 
+    hub._proxy._last_activities_burst_complete = True
     hub._on_activities_burst("activities")
     loop.run_until_complete(asyncio.sleep(0))
 
@@ -1818,6 +1820,7 @@ def test_activity_catalog_name_change_bumps_cache_generation(monkeypatch):
         lambda: ({101: {"name": "New Name", "active": False, "needs_confirm": False}}, True),
     )
 
+    hub._proxy._last_activities_burst_complete = True
     hub._on_activities_burst("activities")
     loop.run_until_complete(asyncio.sleep(0))
 
@@ -2688,6 +2691,7 @@ def test_on_activities_burst_syncs_current_activity_from_active_flag(monkeypatch
     )
 
     hub.current_activity = None
+    hub._proxy._last_activities_burst_complete = True
     hub._on_activities_burst("activities")
     loop.run_until_complete(asyncio.sleep(0))
 
@@ -2800,6 +2804,7 @@ def test_activities_burst_can_clear_current_when_no_activity_active(monkeypatch)
         lambda: ({101: {"name": "Watch a movie", "active": False}}, True),
     )
 
+    hub._proxy._last_activities_burst_complete = True
     hub._on_activities_burst("activities")
     loop.run_until_complete(asyncio.sleep(0))
 
@@ -5130,7 +5135,6 @@ def test_async_request_catalog_prunes_auxiliary_only_removed_activity_ids(monkey
     hub._activities_generation = 2
     hub._proxy.get_known_activity_ids = lambda: {101, 102}  # type: ignore[method-assign]
     hub._proxy.get_cached_activity_detail_ids = lambda: {5, 6, 101, 102}  # type: ignore[method-assign]
-    hub._proxy.clear_activities_catalog = lambda: None  # type: ignore[method-assign]
     hub._proxy.request_activities = lambda: None  # type: ignore[method-assign]
 
     cleared: list[tuple[int, str]] = []
@@ -5148,6 +5152,7 @@ def test_async_request_catalog_prunes_auxiliary_only_removed_activity_ids(monkey
     hub._proxy.get_known_activity_ids = _fake_get_known_activity_ids  # type: ignore[method-assign]
 
     async def _fake_sleep(_delay):
+        hub._proxy._activities_snapshot_generation = 1
         hub._activities_generation = 3
 
     monkeypatch.setattr("custom_components.sofabaton_x1s.hub.asyncio.sleep", _fake_sleep)
@@ -5575,6 +5580,7 @@ def test_hub_event_actions_fire_on_first_transition_after_powered_off_startup(mo
     hub, loop, executed, drain = _make_event_hook_hub(monkeypatch)
     try:
         monkeypatch.setattr(hub, "_get_activities_cached", lambda: ({}, True))
+        hub._proxy._last_activities_burst_complete = True
         hub._on_activities_burst("activities")
         drain()
         assert executed == []
@@ -5748,6 +5754,7 @@ def test_activities_burst_prunes_stale_activity_event_actions(monkeypatch):
         lambda: ({102: {"name": "Music", "active": False, "needs_confirm": False}}, True),
     )
 
+    hub._proxy._last_activities_burst_complete = True
     hub._on_activities_burst("activities")
     loop.run_until_complete(asyncio.sleep(0))
     loop.run_until_complete(asyncio.sleep(0))

--- a/tests/test_hub_snapshots.py
+++ b/tests/test_hub_snapshots.py
@@ -84,6 +84,12 @@ def test_to_export_view_is_a_noop_when_raw_body_absent() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _complete_activity_request(hub):
+    # Simulate a new commit and its HA delivery after the request begins.
+    hub._proxy._activities_snapshot_generation += 1
+    hub._activities_generation += 1
+
+
 def test_refresh_devices_snapshot_carries_raw_body_from_proxy_state(
     monkeypatch,
 ) -> None:
@@ -136,9 +142,8 @@ def test_refresh_activities_snapshot_carries_raw_body_from_proxy_state(
     }
 
     monkeypatch.setattr(
-        hub._proxy, "request_activities", lambda *args, **kwargs: None
+        hub._proxy, "request_activities", lambda: _complete_activity_request(hub)
     )
-    hub._activities_generation += 1
 
     snapshot = hub.hass.loop.run_until_complete(
         hub._async_refresh_activities_snapshot(timeout_seconds=1.0)
@@ -164,9 +169,8 @@ def test_refresh_devices_and_activities_have_identical_shape(monkeypatch) -> Non
     hub._proxy.state.activities[0x02] = {"name": "Act", "raw_body": raw_act}
 
     monkeypatch.setattr(hub._proxy, "request_devices", lambda *a, **kw: None)
-    monkeypatch.setattr(hub._proxy, "request_activities", lambda *a, **kw: None)
+    monkeypatch.setattr(hub._proxy, "request_activities", lambda: _complete_activity_request(hub))
     hub._devices_generation += 1
-    hub._activities_generation += 1
 
     dev_snapshot = hub.hass.loop.run_until_complete(
         hub._async_refresh_devices_snapshot(timeout_seconds=1.0)

--- a/tests/test_hub_snapshots.py
+++ b/tests/test_hub_snapshots.py
@@ -88,6 +88,11 @@ def _complete_activity_request(hub):
     # Simulate a new commit and its HA delivery after the request begins.
     hub._proxy._activities_snapshot_generation += 1
     hub._activities_generation += 1
+    hub._received_activity_snapshot = (
+        hub._proxy,
+        hub._proxy._activities_snapshot_generation,
+        {act_id: dict(row) for act_id, row in hub._proxy.state.activities.items()},
+    )
 
 
 def test_refresh_devices_snapshot_carries_raw_body_from_proxy_state(

--- a/tests/test_opcode_handlers.py
+++ b/tests/test_opcode_handlers.py
@@ -1664,6 +1664,8 @@ def _redundant_off_proxy() -> tuple[X1Proxy, list[str]]:
         "127.0.0.1", proxy_udp_port=0, proxy_enabled=False, diag_dump=False, diag_parse=False
     )
     proxy.enqueue_cmd = lambda *args, **kwargs: True  # type: ignore[assignment]
+    # Direct handle_active_state calls below simulate a committed burst.
+    proxy._last_activities_burst_complete = True
     fired: list[str] = []
     proxy.on_redundant_off_press(lambda: fired.append("off"))
     return proxy, fired
@@ -1740,6 +1742,7 @@ def _external_state_proxy() -> tuple[X1Proxy, list[tuple]]:
     )
     proxy.enqueue_cmd = lambda *args, **kwargs: True  # type: ignore[assignment]
     proxy._activities_catalog_ready = True
+    proxy._last_activities_burst_complete = True
     proxy.state.activities = {0x67: {"name": "Music"}, 0x68: {"name": "Movie"}}
     changes: list[tuple] = []
     proxy.on_activity_change(lambda new_id, old_id, name: changes.append((new_id, old_id, name)))

--- a/tests/test_opcode_handlers.py
+++ b/tests/test_opcode_handlers.py
@@ -825,7 +825,7 @@ def test_macro_handler_drains_completed_burst_immediately(monkeypatch) -> None:
     opcode_two = (OP_MACROS_B1 >> 8) << 8 | (OP_MACROS_B1 & 0xFF)
 
     proxy._pending_macro_requests.add(act)
-    proxy._burst.queue.append((0x025C, b"\x01\x03", True, "commands:1:3"))
+    proxy._burst.queue.append((0x025C, b"\x01\x03", True, "commands:1:3", None))
 
     sent: list[tuple[int, bytes]] = []
 
@@ -1659,11 +1659,26 @@ def test_ack_ready_prefetches_when_cache_missing() -> None:
     assert OP_REQ_COMMANDS not in opcodes
 
 
+def _stub_completed_activity_request(proxy: X1Proxy):
+    """Deliver queued request hooks; tests evaluate the simulated commit below."""
+    def enqueue(opcode, payload=b"", **kwargs):
+        if opcode == OP_REQ_ACTIVITIES:
+            on_send = kwargs.get("on_send")
+            if on_send is not None:
+                on_send()
+            proxy._begin_activity_request()
+            proxy._last_activities_request_generation = proxy._activity_request_inflight
+            proxy._last_activities_burst_complete = True
+        return True
+
+    return enqueue
+
+
 def _redundant_off_proxy() -> tuple[X1Proxy, list[str]]:
     proxy = X1Proxy(
         "127.0.0.1", proxy_udp_port=0, proxy_enabled=False, diag_dump=False, diag_parse=False
     )
-    proxy.enqueue_cmd = lambda *args, **kwargs: True  # type: ignore[assignment]
+    proxy.enqueue_cmd = _stub_completed_activity_request(proxy)  # type: ignore[assignment]
     # Direct handle_active_state calls below simulate a committed burst.
     proxy._last_activities_burst_complete = True
     fired: list[str] = []
@@ -1740,7 +1755,7 @@ def _external_state_proxy() -> tuple[X1Proxy, list[tuple]]:
     proxy = X1Proxy(
         "127.0.0.1", proxy_udp_port=0, proxy_enabled=False, diag_dump=False, diag_parse=False
     )
-    proxy.enqueue_cmd = lambda *args, **kwargs: True  # type: ignore[assignment]
+    proxy.enqueue_cmd = _stub_completed_activity_request(proxy)  # type: ignore[assignment]
     proxy._activities_catalog_ready = True
     proxy._last_activities_burst_complete = True
     proxy.state.activities = {0x67: {"name": "Music"}, 0x68: {"name": "Movie"}}

--- a/tests/test_state_helpers.py
+++ b/tests/test_state_helpers.py
@@ -37,6 +37,28 @@ def test_burst_scheduler_drains_queue_and_notifies() -> None:
     assert notifications == ["foo"]
 
 
+def test_burst_scheduler_keeps_send_hooks_with_their_commands() -> None:
+    scheduler = BurstScheduler()
+    events = []
+    sender = lambda op, payload: events.append(("send", op))
+    for opcode in (1, 2, 3):
+        assert scheduler.queue_or_send(
+            opcode=opcode,
+            payload=b"",
+            expects_burst=True,
+            burst_kind=str(opcode),
+            can_issue=lambda: True,
+            sender=sender,
+            on_send=lambda op=opcode: events.append(("bind", op)),
+        )
+    assert events == [("bind", 1), ("send", 1)]
+    assert scheduler.finish("1", can_issue=lambda: True, sender=sender)
+    assert events == [("bind", 1), ("send", 1), ("bind", 2), ("send", 2)]
+    # A command dropped before transmission must never bind its intent.
+    assert scheduler.finish("2", can_issue=lambda: False, sender=sender)
+    assert events == [("bind", 1), ("send", 1), ("bind", 2), ("send", 2)]
+
+
 def test_burst_scheduler_tick_never_drains_exchange_pseudo_burst() -> None:
     """An ``exchange:`` pseudo-burst is exempt from the idle tick.
 

--- a/tests/test_transport_bridge.py
+++ b/tests/test_transport_bridge.py
@@ -302,13 +302,17 @@ def test_bridge_loop_moves_hub_bytes_and_counts_stats():
         ):
             time.sleep(0.01)
     finally:
-        bridge.stop()
+        # Quiesce the test-owned worker before closing its sockets.
+        bridge._stop.set()
+        bridge._signal_wake()
         thr.join(5.0)
+        bridge.stop()
         try:
             peer.close()
         except OSError:
             pass
 
+    assert not thr.is_alive()
     assert received[0] == b"hello"
     stats = bridge.get_bridge_stats()
     assert stats["hub_rx_bytes"] == len(b"hello")


### PR DESCRIPTION
An incomplete or silent activity-catalog refresh could clear the committed active state and publish a false Off transition. The next complete read then started the same activity again. Preserve the last complete catalog during refresh, and publish activity changes only from a complete response. Authoritative inactive and empty catalogs still report Off normally.

- A refresh acknowledges the proxy identity, committed generation and copied raw rows together. An old Home Assistant callback cannot certify a newer proxy commit. Command validation and detail pruning use the acknowledged snapshot; failed refreshes return a timeout without persisting success or starting command deployment.
- A genuine redundant-Off press owns its queued confirmation request and permitted X2 retry. Earlier reads cannot confirm or cancel it. Disconnect, absolute expiry, failed confirmation and a canceled retry clear the intent so later recovery cannot replay an old press.
- Regression coverage exercises the callback/commit race, replaced proxies, silent/partial/empty reads, older queued reads, superseding presses, retry cancellation, expiry, disconnect and genuine Off behavior across X1/X1S/X2.

The transport test now joins its own worker before closing sockets, preserving its traffic/counter assertions and removing a teardown race reproduced on the unchanged base transport.

The Python CI workflow also gains a manual dispatch trigger.

Independent Sol 5.6 xhigh review of the exact final source returned MERGE_READY after the material findings were reproduced and corrected.

All seven GitHub Actions checks pass for `404cfd1`: [full integration suite, library tests on Python 3.11/3.12/3.13 and build/install smoke](https://github.com/m3tac0de/home-assistant-sofabaton-x1s/actions/runs/33699822391), [Hassfest](https://github.com/m3tac0de/home-assistant-sofabaton-x1s/actions/runs/33699822411), and [HACS](https://github.com/m3tac0de/home-assistant-sofabaton-x1s/actions/runs/33699822432).

Reconnect readiness still requires a complete catalog, so an incomplete first read can leave the index and MQTT ingress waiting for a later successful read. The pre-existing ACK/MQTT settling marker also remains independent of request ownership; an overlapping older read can still cause a settling delay. These are nonblocking follow-ups.
